### PR TITLE
correct deixis

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -12,7 +12,7 @@ It does **NOT** depend on ncurses.
 
 * License: MIT
 * Platform: linux and any xterm-compatible terminal.
-  Those terminals have been successfully tested:
+  These terminals have been successfully tested:
 	* xterm
 	* gnome-terminal
 	* Konsole


### PR DESCRIPTION
In English we would use "these" in this context.  I can't explain why, but it probably has something to do with the fact that they have not yet been mentioned when the word "these" is spoken/written/heard/read.  "Those" might be used if the terminals had already been mentioned.