### PR TITLE
Added support for "default" colors in ScreenBuffer

### DIFF
--- a/demo/spaceship.js
+++ b/demo/spaceship.js
@@ -87,6 +87,7 @@ function terminate()
 function createBackground()
 {
 	sprites.background = ScreenBuffer.create( { width: viewport.width * 4 , height: viewport.height } ) ;
+	sprites.background.fill( { attr: { bgColor: 'black' } } )
 	
 	sprites.planet = ScreenBuffer.createFromChars(
 		{ attr: { color: 'yellow' , bold: false } , transparencyChar: ' ' } ,
@@ -117,7 +118,7 @@ function createBackgroundTrails( nTrails )
 			sprites.background.put( {
 				x: ( x + j ) % sprites.background.width ,
 				y: y ,
-				attr: { color: 8 }
+				attr: { color: 8 , bgColor: 0 }
 			} , '-' ) ;
 		}
 	}
@@ -139,7 +140,7 @@ function createBackgroundStars( nStars )
 		sprites.background.put( {
 			x: x ,
 			y: y ,
-			attr: { color: c }
+			attr: { color: c , bgColor: 0 }
 		} , char ) ;
 	}
 }

--- a/lib/ScreenBuffer.js
+++ b/lib/ScreenBuffer.js
@@ -799,7 +799,19 @@ ScreenBuffer.prototype.terminalBlitterCellIterator = function terminalBlitterCel
 	p.context.cy = p.dstY ;
 } ;
 
+// reads version 1 & 2 files and unpacks their attr values into the v3+ arrangement
+function convertAndCopy(src, dst, start){
+	for ( var offset = start , cursor = 0 ; offset < src.length ; offset += 8 )
+	{
+		var flags = src.readUInt16BE( offset ) ,
+			colors = src.readUInt16BE( offset + 2 ) ,
+			char = ScreenBuffer.prototype.readChar( src, offset + 4 - ScreenBuffer.prototype.ATTR_SIZE ) ;
 
+		dst.writeUIntBE( colors*Math.pow(2,32) + flags , cursor , ScreenBuffer.prototype.ATTR_SIZE ) ;
+		dst.write( char , cursor + ScreenBuffer.prototype.ATTR_SIZE ) ;
+		cursor += ScreenBuffer.prototype.ITEM_SIZE ;
+	}
+}
 
 ScreenBuffer.loadSyncV1 = function loadSync( filepath )
 {
@@ -830,7 +842,7 @@ ScreenBuffer.loadSyncV1 = function loadSync( filepath )
 		height: height
 	} ) ;
 	
-	content.copy( screenBuffer.buffer , 0 , HEADER_SIZE ) ;
+	convertAndCopy( content , screenBuffer.buffer , HEADER_SIZE ) ; 
 	
 	return screenBuffer ;
 } ;
@@ -862,7 +874,7 @@ ScreenBuffer.prototype.saveSyncV1 = function saveSync( filepath )
 
 
 
-ScreenBuffer.loadSyncV2 = function loadSync( filepath )
+ScreenBuffer.loadSyncV2and3 = function loadSync( filepath )
 {
 	var i , content , header , screenBuffer ;
 	
@@ -907,7 +919,8 @@ ScreenBuffer.loadSyncV2 = function loadSync( filepath )
 	}
 	
 	// Bad size?
-	if ( content.length !== i + 1 + header.width * header.height * ScreenBuffer.prototype.ITEM_SIZE )
+	var itemSize = header.version === 2 ? 8 : ScreenBuffer.prototype.ITEM_SIZE ;
+	if ( content.length !== i + 1 + header.width * header.height * itemSize )
 	{
 		throw new Error( 'Bad file size: this is a corrupted ScreenBuffer file' ) ;
 	}
@@ -917,8 +930,15 @@ ScreenBuffer.loadSyncV2 = function loadSync( filepath )
 		width: header.width ,
 		height: header.height
 	} ) ;
-	
-	content.copy( screenBuffer.buffer , 0 , i + 1 ) ;
+
+	if ( header.version === 2 )
+	{
+		convertAndCopy( content, screenBuffer.buffer , i + 1 ) ;
+	} 
+	else if ( header.version === 3 )
+	{
+		content.copy( screenBuffer.buffer , 0 , i + 1 ) ;
+	}
 	
 	return screenBuffer ;
 } ;
@@ -929,12 +949,12 @@ ScreenBuffer.loadSyncV2 = function loadSync( filepath )
 // The header start with a magic number SB\n then a compact single-line JSON that end with an \n.
 // So the data part start after the second \n, providing a variable header size.
 // This will allow adding meta data without actually changing the file format.
-ScreenBuffer.prototype.saveSyncV2 = function saveSync( filepath )
+ScreenBuffer.prototype.saveSyncV3 = function saveSync( filepath )
 {
 	var content , header ;
 	
 	header = {
-		version: 2 ,
+		version: 3 ,
 		width: this.width ,
 		height: this.height ,
 		bpp: this.bpp
@@ -953,8 +973,8 @@ ScreenBuffer.prototype.saveSyncV2 = function saveSync( filepath )
 
 
 
-ScreenBuffer.loadSync = ScreenBuffer.loadSyncV2 ;
-ScreenBuffer.prototype.saveSync = ScreenBuffer.prototype.saveSyncV2 ;
+ScreenBuffer.loadSync = ScreenBuffer.loadSyncV2and3 ;
+ScreenBuffer.prototype.saveSync = ScreenBuffer.prototype.saveSyncV3 ;
 
 
 

--- a/lib/ScreenBuffer.js
+++ b/lib/ScreenBuffer.js
@@ -1084,14 +1084,14 @@ ScreenBuffer.prototype.dump = function dump()
 
 ScreenBuffer.prototype.readAttr = function readAttr( buffer , at )
 {
-	return buffer.readInt32BE( at ) ;
+	return buffer.readUIntBE( at , this.ATTR_SIZE ) ;
 } ;
 
 
 
 ScreenBuffer.prototype.writeAttr = function writeAttr( buffer , attr , at )
 {
-	return buffer.writeInt32BE( attr , at ) ;
+	return buffer.writeUIntBE( attr , at , this.ATTR_SIZE) ;
 } ;
 
 
@@ -1126,8 +1126,9 @@ ScreenBuffer.prototype.writeChar = function writeChar( buffer , char , at )
 
 ScreenBuffer.prototype.generateEscapeSequence = function generateEscapeSequence( term , attr )
 {
-	var color = attr & 255 ;
-	var bgColor = ( attr >>> 8 ) & 255 ;
+	var colors = attr / Math.pow(2, 32) ,
+		color = colors & 255 ,
+		bgColor = ( colors >>> 8 ) & 255 ;
 	
 	var esc = term.optimized.styleReset +
 		term.optimized.color256[ color ] +
@@ -1155,10 +1156,12 @@ ScreenBuffer.prototype.generateDeltaEscapeSequence = function generateDeltaEscap
 	//console.log( 'generateDeltaEscapeSequence' ) ;
 	
 	var esc = '' ,
-		color = attr & 255 ,
-		lastColor = lastAttr & 255 ,
-		bgColor = ( attr >>> 8 ) & 255 ,
-		lastBgColor = ( lastAttr >>> 8 ) & 255 ;
+		colors = attr / Math.pow(2, 32) ,
+		lastColors = lastAttr / Math.pow(2, 32) ,
+		color = colors & 255 ,
+		lastColor = lastColors & 255 ,
+		bgColor = ( colors >>> 8 ) & 255 ,
+		lastBgColor = ( lastColors >>> 8 ) & 255 ;
 	
 	if ( color !== lastColor ) { esc += term.optimized.color256[ color ] ; }
 	if ( bgColor !== lastBgColor ) { esc += term.optimized.bgColor256[ bgColor ] ; }
@@ -1276,10 +1279,10 @@ ScreenBuffer.prototype.vScroll = function vScroll( lineOffset , drawToTerminal )
 
 ScreenBuffer.prototype.attr2object = ScreenBuffer.attr2object = function attr2object( attr )
 {
-	var object = {} ;
-	
-	object.color = attr & 255 ;
-	object.bgColor = ( attr >>> 8 ) & 255 ;
+	var object = {} ,
+		colors = attr / Math.pow(2, 32) ;
+	object.color = colors & 255 ;
+	object.bgColor = ( colors >>> 8 ) & 255 ;
 	
 	// Style part
 	if ( attr & BOLD ) { object.bold = true ; }
@@ -1307,7 +1310,7 @@ ScreenBuffer.prototype.attr2object = ScreenBuffer.attr2object = function attr2ob
 
 ScreenBuffer.prototype.object2attr = ScreenBuffer.object2attr = function object2attr( object )
 {
-	var attr = 0 ;
+	var attr = 0 , colors = 0 ;
 	
 	if ( ! object || typeof object !== 'object' ) { object = {} ; }
 	
@@ -1316,14 +1319,14 @@ ScreenBuffer.prototype.object2attr = ScreenBuffer.object2attr = function object2
 	if ( typeof object.color !== 'number' || object.color < 0 || object.color > 255 ) { object.color = 7 ; }
 	else { object.color = Math.floor( object.color ) ; }
 	
-	attr += object.color ;
+	colors += object.color ;
 	
 	// Background color part
 	if ( typeof object.bgColor === 'string' ) { object.bgColor = termkit.color2index( object.bgColor ) ; }
 	if ( typeof object.bgColor !== 'number' || object.bgColor < 0 || object.bgColor > 255 ) { object.bgColor = 0 ; }
 	else { object.bgColor = Math.floor( object.bgColor ) ; }
 	
-	attr += object.bgColor << 8 ;
+	colors += object.bgColor << 8 ;
 	
 	// Style part
 	if ( object.bold ) { attr |= BOLD ; }
@@ -1344,10 +1347,8 @@ ScreenBuffer.prototype.object2attr = ScreenBuffer.object2attr = function object2
 	
 	if ( object.void ) { attr |= VOID ; }
 	
-	return attr ;
+	return colors*Math.pow(2, 32) + attr ;
 } ;
-
-
 
 
 
@@ -1371,31 +1372,31 @@ ScreenBuffer.prototype.clear = ScreenBuffer.prototype.fill ;
 const NONE = 0 ;	// Nothing
 
 // Style mask and flags
-const STYLE_MASK = 255 << 16 ;
+const STYLE_MASK = 255 ;
 
-const BOLD = 1 << 16 ;
-const DIM = 2 << 16 ;
-const ITALIC = 4 << 16 ;
-const UNDERLINE = 8 << 16 ;
-const BLINK = 16 << 16 ;
-const INVERSE = 32 << 16 ;
-const HIDDEN = 64 << 16 ;
-const STRIKE = 128 << 16 ;
+const BOLD = 1 ;
+const DIM = 2 ;
+const ITALIC = 4 ;
+const UNDERLINE = 8 ;
+const BLINK = 16 ;
+const INVERSE = 32 ;
+const HIDDEN = 64 ;
+const STRIKE = 128 ;
 
 const BOLD_DIM = BOLD | DIM ;
 
 // Blending flags, mask and misc flags
-const FG_TRANSPARENCY = 1 << 24 ;
-const BG_TRANSPARENCY = 2 << 24 ;
-const STYLE_TRANSPARENCY = 4 << 24 ;
-const CHAR_TRANSPARENCY = 8 << 24 ;
+const FG_TRANSPARENCY = 1 << 8 ;
+const BG_TRANSPARENCY = 2 << 8 ;
+const STYLE_TRANSPARENCY = 4 << 8 ;
+const CHAR_TRANSPARENCY = 8 << 8 ;
 const TRANSPARENCY = FG_TRANSPARENCY | BG_TRANSPARENCY | STYLE_TRANSPARENCY | CHAR_TRANSPARENCY ;
 
 // E.g.: if it needs redraw
-const VOID = 32 << 24 ;
+const VOID = 32 << 8 ;
 
-const LEADING_FULLWIDTH = 64 << 24 ;
-const TRAILING_FULLWIDTH = 128 << 24 ;
+const LEADING_FULLWIDTH = 64 << 8 ;
+const TRAILING_FULLWIDTH = 128 << 8 ;
 
 // Unused bits: 16
 
@@ -1410,19 +1411,18 @@ const HEADER_SIZE = 40 ;	// Header consists of 40 bytes
 
 
 // Data structure
-ScreenBuffer.prototype.ATTR_SIZE = 4 ;	// do not edit, everything use Buffer.writeInt32BE()
-ScreenBuffer.prototype.CHAR_SIZE = 4 ;
+ScreenBuffer.prototype.ATTR_SIZE = 6 ;	// do not edit, attrs use 48-bit Buffer.writeUIntBE()
+ScreenBuffer.prototype.CHAR_SIZE = 4 ;	//              chars use 32 bits 
 ScreenBuffer.prototype.ITEM_SIZE = ScreenBuffer.prototype.ATTR_SIZE + ScreenBuffer.prototype.CHAR_SIZE ;
 
 ScreenBuffer.prototype.DEFAULT_ATTR = ScreenBuffer.object2attr( { color: 'white' , bgColor: 'black' } ) ;
 
 ScreenBuffer.prototype.CLEAR_ATTR = ScreenBuffer.object2attr( { color: 'white' , bgColor: 'black' , transparency: true } ) ;
 ScreenBuffer.prototype.CLEAR_BUFFER = Buffer.allocUnsafe( ScreenBuffer.prototype.ITEM_SIZE ) ;
-ScreenBuffer.prototype.CLEAR_BUFFER.writeInt32BE( ScreenBuffer.prototype.CLEAR_ATTR , 0 ) ;
+ScreenBuffer.prototype.CLEAR_BUFFER.writeUIntBE( ScreenBuffer.prototype.CLEAR_ATTR , 0 , ScreenBuffer.prototype.ATTR_SIZE) ;
 ScreenBuffer.prototype.CLEAR_BUFFER.write( ' \x00\x00\x00' , ScreenBuffer.prototype.ATTR_SIZE ) ;	// space
 
 ScreenBuffer.prototype.CLEAR_VOID_ATTR = ScreenBuffer.object2attr( { void: true } ) ;
 ScreenBuffer.prototype.CLEAR_VOID_BUFFER = Buffer.allocUnsafe( ScreenBuffer.prototype.ITEM_SIZE ) ;
-ScreenBuffer.prototype.CLEAR_VOID_BUFFER.writeInt32BE( ScreenBuffer.prototype.CLEAR_VOID_ATTR , 0 ) ;
+ScreenBuffer.prototype.CLEAR_VOID_BUFFER.writeUIntBE( ScreenBuffer.prototype.CLEAR_VOID_ATTR , 0 , ScreenBuffer.prototype.ATTR_SIZE) ;
 ScreenBuffer.prototype.CLEAR_VOID_BUFFER.write( ' \x00\x00\x00' , ScreenBuffer.prototype.ATTR_SIZE ) ;	// space
-

--- a/lib/ScreenBuffer.js
+++ b/lib/ScreenBuffer.js
@@ -802,16 +802,18 @@ ScreenBuffer.prototype.terminalBlitterCellIterator = function terminalBlitterCel
 function convertAndCopy(src, dst, start)
 {
 	// walk v1 & v2 files and unpack their 4-byte attr values into the 6-byte arrangement for v3+ 
+	var attr_size = ScreenBuffer.prototype.ATTR_SIZE ,
+		item_size = ScreenBuffer.prototype.ITEM_SIZE ;
 	for ( var offset = start , cursor = 0 ; offset < src.length ; offset += 8 )
 	{
 		var flags = src.readUInt16BE( offset ) ,
 			colors = src.readUInt16BE( offset + 2 ) ,
-			char = ScreenBuffer.prototype.readChar( src, offset + 4 - ScreenBuffer.prototype.ATTR_SIZE ) ;
+			char = ScreenBuffer.prototype.readChar( src, offset + 4 - attr_size ) ;
 
 		flags |= ( HAS_COLOR | HAS_BACKGROUND ) ; // colors were manditory pre-v3
-		dst.writeUIntBE( colors*Math.pow(2,32) + flags , cursor , ScreenBuffer.prototype.ATTR_SIZE ) ;
-		dst.write( char , cursor + ScreenBuffer.prototype.ATTR_SIZE ) ;
-		cursor += ScreenBuffer.prototype.ITEM_SIZE ;
+		dst.writeUIntBE( colors * Math.pow( 256 , attr_size-2 ) + flags , cursor , attr_size ) ;
+		dst.write( char , cursor + attr_size ) ;
+		cursor += item_size ;
 	}
 }
 
@@ -1148,7 +1150,7 @@ ScreenBuffer.prototype.writeChar = function writeChar( buffer , char , at )
 
 ScreenBuffer.prototype.generateEscapeSequence = function generateEscapeSequence( term , attr )
 {
-	var colors = attr / Math.pow(2, 32) ,
+	var colors = attr / Math.pow( 256 , this.ATTR_SIZE - 2 ) ,
 		color = colors & 255 ,
 		bgColor = ( colors >>> 8 ) & 255 ;
 	
@@ -1179,8 +1181,8 @@ ScreenBuffer.prototype.generateDeltaEscapeSequence = function generateDeltaEscap
 	//console.log( 'generateDeltaEscapeSequence' ) ;
 	
 	var esc = '' ,
-		colors = attr / Math.pow(2, 32) ,
-		lastColors = lastAttr / Math.pow(2, 32) ,
+		colors = attr / Math.pow( 256 , this.ATTR_SIZE - 2 ) ,
+		lastColors = lastAttr / Math.pow( 256 , this.ATTR_SIZE - 2 ) ,
 		color = colors & 255 ,
 		lastColor = lastColors & 255 ,
 		bgColor = ( colors >>> 8 ) & 255 ,
@@ -1312,7 +1314,7 @@ ScreenBuffer.prototype.vScroll = function vScroll( lineOffset , drawToTerminal )
 ScreenBuffer.prototype.attr2object = ScreenBuffer.attr2object = function attr2object( attr )
 {
 	var object = {} ,
-		colors = attr / Math.pow(2, 32) ;
+		colors = attr / Math.pow( 256 , this.ATTR_SIZE - 2 ) ;
 	object.color = colors & 255 ;
 	if ( ! ( attr & HAS_COLOR ) ) { delete object.color ; }
 	object.bgColor = ( colors >>> 8 ) & 255 ;
@@ -1383,7 +1385,7 @@ ScreenBuffer.prototype.object2attr = ScreenBuffer.object2attr = function object2
 	
 	if ( object.void ) { attr |= VOID ; }
 	
-	return colors*Math.pow(2, 32) + attr ;
+	return colors * Math.pow( 256 , this.ATTR_SIZE - 2 ) + attr ;
 } ;
 
 

--- a/lib/ScreenBuffer.js
+++ b/lib/ScreenBuffer.js
@@ -799,14 +799,16 @@ ScreenBuffer.prototype.terminalBlitterCellIterator = function terminalBlitterCel
 	p.context.cy = p.dstY ;
 } ;
 
-// reads version 1 & 2 files and unpacks their attr values into the v3+ arrangement
-function convertAndCopy(src, dst, start){
+function convertAndCopy(src, dst, start)
+{
+	// walk v1 & v2 files and unpack their 4-byte attr values into the 6-byte arrangement for v3+ 
 	for ( var offset = start , cursor = 0 ; offset < src.length ; offset += 8 )
 	{
 		var flags = src.readUInt16BE( offset ) ,
 			colors = src.readUInt16BE( offset + 2 ) ,
 			char = ScreenBuffer.prototype.readChar( src, offset + 4 - ScreenBuffer.prototype.ATTR_SIZE ) ;
 
+		flags |= ( HAS_COLOR | HAS_BACKGROUND ) ; // colors were manditory pre-v3
 		dst.writeUIntBE( colors*Math.pow(2,32) + flags , cursor , ScreenBuffer.prototype.ATTR_SIZE ) ;
 		dst.write( char , cursor + ScreenBuffer.prototype.ATTR_SIZE ) ;
 		cursor += ScreenBuffer.prototype.ITEM_SIZE ;
@@ -1150,9 +1152,10 @@ ScreenBuffer.prototype.generateEscapeSequence = function generateEscapeSequence(
 		color = colors & 255 ,
 		bgColor = ( colors >>> 8 ) & 255 ;
 	
-	var esc = term.optimized.styleReset +
-		term.optimized.color256[ color ] +
-		term.optimized.bgColor256[ bgColor ] ;
+	var esc = term.optimized.styleReset ;
+
+	if ( attr & HAS_COLOR ) { esc += term.optimized.color256[ color ] ; }
+	if ( attr & HAS_BACKGROUND ) { esc += term.optimized.bgColor256[ bgColor ] ; }
 	
 	// Style part
 	if ( attr & BOLD ) { esc += term.optimized.bold ; }
@@ -1183,8 +1186,17 @@ ScreenBuffer.prototype.generateDeltaEscapeSequence = function generateDeltaEscap
 		bgColor = ( colors >>> 8 ) & 255 ,
 		lastBgColor = ( lastColors >>> 8 ) & 255 ;
 	
-	if ( color !== lastColor ) { esc += term.optimized.color256[ color ] ; }
-	if ( bgColor !== lastBgColor ) { esc += term.optimized.bgColor256[ bgColor ] ; }
+
+	if ( color !== lastColor || (attr & HAS_COLOR) !== (lastAttr & HAS_COLOR) ) 
+	{
+		if (attr & HAS_COLOR) esc += term.optimized.color256[ color ] ;
+		else esc += term.optimized.defaultColor ;
+	}
+	if ( bgColor !== lastBgColor || (attr & HAS_BACKGROUND) !== (lastAttr & HAS_BACKGROUND) ) 
+	{ 
+		if (attr & HAS_BACKGROUND) esc += term.optimized.bgColor256[ bgColor ] ; 
+		else esc += term.optimized.bgDefaultColor ;
+	}
 	
 	if ( ( attr & STYLE_MASK ) !== ( lastAttr & STYLE_MASK ) )
 	{
@@ -1302,7 +1314,9 @@ ScreenBuffer.prototype.attr2object = ScreenBuffer.attr2object = function attr2ob
 	var object = {} ,
 		colors = attr / Math.pow(2, 32) ;
 	object.color = colors & 255 ;
+	if ( ! ( attr & HAS_COLOR ) ) { delete object.color ; }
 	object.bgColor = ( colors >>> 8 ) & 255 ;
+	if ( ! ( attr & HAS_BACKGROUND ) ) { delete object.bgColor ; }
 	
 	// Style part
 	if ( attr & BOLD ) { object.bold = true ; }
@@ -1335,6 +1349,7 @@ ScreenBuffer.prototype.object2attr = ScreenBuffer.object2attr = function object2
 	if ( ! object || typeof object !== 'object' ) { object = {} ; }
 	
 	// Color part
+	if ( object.color !== undefined && object.color !== 'default' ) { attr |= HAS_COLOR ; }
 	if ( typeof object.color === 'string' ) { object.color = termkit.color2index( object.color ) ; }
 	if ( typeof object.color !== 'number' || object.color < 0 || object.color > 255 ) { object.color = 7 ; }
 	else { object.color = Math.floor( object.color ) ; }
@@ -1342,6 +1357,7 @@ ScreenBuffer.prototype.object2attr = ScreenBuffer.object2attr = function object2
 	colors += object.color ;
 	
 	// Background color part
+	if ( object.bgColor !== undefined && object.bgColor !== 'default' ) { attr |= HAS_BACKGROUND ; }
 	if ( typeof object.bgColor === 'string' ) { object.bgColor = termkit.color2index( object.bgColor ) ; }
 	if ( typeof object.bgColor !== 'number' || object.bgColor < 0 || object.bgColor > 255 ) { object.bgColor = 0 ; }
 	else { object.bgColor = Math.floor( object.bgColor ) ; }
@@ -1415,12 +1431,14 @@ const TRANSPARENCY = FG_TRANSPARENCY | BG_TRANSPARENCY | STYLE_TRANSPARENCY | CH
 // E.g.: if it needs redraw
 const VOID = 32 << 8 ;
 
+// Unused bit: 16 << 8
+
 const LEADING_FULLWIDTH = 64 << 8 ;
 const TRAILING_FULLWIDTH = 128 << 8 ;
 
-// Unused bits: 16
-
-
+// flag presence of non-default color & bgColor
+const HAS_COLOR = 1 << 16 ;
+const HAS_BACKGROUND = 2 << 16 ;
 
 // Tuning
 const OUTPUT_THRESHOLD = 10000 ;	// minimum amount of data to retain before sending them to the terminal
@@ -1435,9 +1453,8 @@ ScreenBuffer.prototype.ATTR_SIZE = 6 ;	// do not edit, attrs use 48-bit Buffer.w
 ScreenBuffer.prototype.CHAR_SIZE = 4 ;	//              chars use 32 bits 
 ScreenBuffer.prototype.ITEM_SIZE = ScreenBuffer.prototype.ATTR_SIZE + ScreenBuffer.prototype.CHAR_SIZE ;
 
-ScreenBuffer.prototype.DEFAULT_ATTR = ScreenBuffer.object2attr( { color: 'white' , bgColor: 'black' } ) ;
-
-ScreenBuffer.prototype.CLEAR_ATTR = ScreenBuffer.object2attr( { color: 'white' , bgColor: 'black' , transparency: true } ) ;
+ScreenBuffer.prototype.DEFAULT_ATTR = ScreenBuffer.object2attr( { color: 'default' , bgColor: 'default' } ) ;
+ScreenBuffer.prototype.CLEAR_ATTR = ScreenBuffer.object2attr( { color: 'default' , bgColor: 'default' , transparency: true } ) ;
 ScreenBuffer.prototype.CLEAR_BUFFER = Buffer.allocUnsafe( ScreenBuffer.prototype.ITEM_SIZE ) ;
 ScreenBuffer.prototype.CLEAR_BUFFER.writeUIntBE( ScreenBuffer.prototype.CLEAR_ATTR , 0 , ScreenBuffer.prototype.ATTR_SIZE) ;
 ScreenBuffer.prototype.CLEAR_BUFFER.write( ' \x00\x00\x00' , ScreenBuffer.prototype.ATTR_SIZE ) ;	// space

--- a/lib/ScreenBuffer.js
+++ b/lib/ScreenBuffer.js
@@ -1274,7 +1274,7 @@ ScreenBuffer.prototype.vScroll = function vScroll( lineOffset , drawToTerminal )
 
 
 
-ScreenBuffer.attr2object = function attr2object( attr )
+ScreenBuffer.prototype.attr2object = ScreenBuffer.attr2object = function attr2object( attr )
 {
 	var object = {} ;
 	
@@ -1305,82 +1305,7 @@ ScreenBuffer.attr2object = function attr2object( attr )
 
 
 
-ScreenBuffer.prototype.attr2object = function attr2object( attr )
-{
-	var object = {} ;
-	
-	object.color = attr & 255 ;
-	object.bgColor = ( attr >>> 8 ) & 255 ;
-	
-	// Style part
-	if ( attr & BOLD ) { object.bold = true ; }
-	if ( attr & DIM ) { object.dim = true ; }
-	if ( attr & ITALIC ) { object.italic = true ; }
-	if ( attr & UNDERLINE ) { object.underline = true ; }
-	if ( attr & BLINK ) { object.blink = true ; }
-	if ( attr & INVERSE ) { object.inverse = true ; }
-	if ( attr & HIDDEN ) { object.hidden = true ; }
-	if ( attr & STRIKE ) { object.strike = true ; }
-	
-	// Blending part
-	if ( attr & FG_TRANSPARENCY ) { object.fgTransparency = true ; }
-	if ( attr & BG_TRANSPARENCY ) { object.bgTransparency = true ; }
-	if ( attr & STYLE_TRANSPARENCY ) { object.styleTransparency = true ; }
-	if ( attr & CHAR_TRANSPARENCY ) { object.charTransparency = true ; }
-	if ( ( attr & TRANSPARENCY ) === TRANSPARENCY ) { object.transparency = true ; }
-	
-	if ( attr & VOID ) { object.void = true ; }
-	
-	return object ;
-} ;
-
-
-
-ScreenBuffer.object2attr = function object2attr( object )
-{
-	var attr = 0 ;
-	
-	if ( ! object || typeof object !== 'object' ) { object = {} ; }
-	
-	// Color part
-	if ( typeof object.color === 'string' ) { object.color = termkit.color2index( object.color ) ; }
-	if ( typeof object.color !== 'number' || object.color < 0 || object.color > 255 ) { object.color = 7 ; }
-	else { object.color = Math.floor( object.color ) ; }
-	
-	attr += object.color ;
-	
-	// Background color part
-	if ( typeof object.bgColor === 'string' ) { object.bgColor = termkit.color2index( object.bgColor ) ; }
-	if ( typeof object.bgColor !== 'number' || object.bgColor < 0 || object.bgColor > 255 ) { object.bgColor = 0 ; }
-	else { object.bgColor = Math.floor( object.bgColor ) ; }
-	
-	attr += object.bgColor << 8 ;
-	
-	// Style part
-	if ( object.bold ) { attr |= BOLD ; }
-	if ( object.dim ) { attr |= DIM ; }
-	if ( object.italic ) { attr |= ITALIC ; }
-	if ( object.underline ) { attr |= UNDERLINE ; }
-	if ( object.blink ) { attr |= BLINK ; }
-	if ( object.inverse ) { attr |= INVERSE ; }
-	if ( object.hidden ) { attr |= HIDDEN ; }
-	if ( object.strike ) { attr |= STRIKE ; }
-	
-	// Blending part
-	if ( object.transparency ) { attr |= TRANSPARENCY ; }
-	if ( object.fgTransparency ) { attr |= FG_TRANSPARENCY ; }
-	if ( object.bgTransparency ) { attr |= BG_TRANSPARENCY ; }
-	if ( object.styleTransparency ) { attr |= STYLE_TRANSPARENCY ; }
-	if ( object.charTransparency ) { attr |= CHAR_TRANSPARENCY ; }
-	
-	if ( object.void ) { attr |= VOID ; }
-	
-	return attr ;
-} ;
-
-
-
-ScreenBuffer.prototype.object2attr = function object2attr( object )
+ScreenBuffer.prototype.object2attr = ScreenBuffer.object2attr = function object2attr( object )
 {
 	var attr = 0 ;
 	

--- a/lib/Terminal.js
+++ b/lib/Terminal.js
@@ -489,6 +489,8 @@ function createOptimized( term )
 	// Colors
 	term.optimized.color256 = [] ;
 	term.optimized.bgColor256 = [] ;
+	term.optimized.defaultColor = term.str.defaultColor()
+	term.optimized.bgDefaultColor = term.str.bgDefaultColor()
 	
 	for ( i = 0 ; i <= 255 ; i ++ )
 	{

--- a/lib/inputField.js
+++ b/lib/inputField.js
@@ -51,6 +51,8 @@ var defaultKeyBindings = {
 	TAB: 'autoComplete' ,
 	CTRL_LEFT: 'previousWord' ,
 	CTRL_RIGHT: 'nextWord' ,
+	ALT_D: 'deleteNextWord' ,
+	CTRL_W: 'deletePreviousWord' ,
 	CTRL_U: 'deleteAllBefore' ,
 	CTRL_K: 'deleteAllAfter'
 } ;
@@ -628,6 +630,51 @@ module.exports = function inputField( options , callback )
 							// Need forceClear
 							redraw( undefined , true ) ;
 							if ( dynamic.autoCompleteHint ) { autoCompleteHint() ; }
+						}
+					}
+					break ;
+				
+				case 'deletePreviousWord' :
+					if ( inputs[ inputIndex ].length && offset > 0 )
+					{
+						if ( dynamic.autoCompleteHint && offset === inputs[ inputIndex ].length )
+						{
+							clearHint() ;
+						}
+						
+						var endpoint = offset -- ;
+						while ( offset > 0 && inputs[ inputIndex ][ offset ] === ' ' ) { offset -- ; }
+						while ( offset > 0 && inputs[ inputIndex ][ offset - 1 ] !== ' ' ) { offset -- ; }
+						inputs[ inputIndex ].splice( offset , endpoint - offset ) ;
+
+						if ( echo )
+						{
+							computeAllCoordinate() ;
+							this.moveTo( cursor.x , cursor.y ) ;
+							redraw( undefined , true ) ;
+						}
+					}
+					break ;
+
+				case 'deleteNextWord' :
+					if ( inputs[ inputIndex ].length && offset < inputs[ inputIndex ].length )
+					{
+						var start = offset ;
+						while ( offset < inputs[ inputIndex ].length && inputs[ inputIndex ][ offset ] === ' ' ) { offset ++ ; }
+						while ( offset < inputs[ inputIndex ].length && inputs[ inputIndex ][ offset ] !== ' ' ) { offset ++ ; }
+						inputs[ inputIndex ].splice( start , offset - start ) ;
+						offset = Math.min( inputs[ inputIndex ].length , start ) ;
+
+						if ( echo )
+						{
+							computeAllCoordinate() ;
+							this.moveTo( cursor.x , cursor.y ) ;
+							redraw( undefined , true ) ;
+						}
+						
+						if ( dynamic.autoCompleteHint && offset === inputs[ inputIndex ].length )
+						{
+							autoCompleteHint() ;
 						}
 					}
 					break ;


### PR DESCRIPTION
Since all but one of the 32 `attr` bits were already in use, I expanded the attr size from 4 bytes to 6 and in the process reordered the 'colors' and 'flags' such that the colors are now in the upper 16 bits and the flags in the lower 16 (which ends up being more convenient for checking bitmasks since the bitwise operators all truncate Number values to 32 bits).

After adding this extra space to the middle of the `attr` field I assigned two new flag bits (at 17 & 18) that indicate whether a `color` and/or `bgColor` have been selected respectively. If they were left undefined (or passed a string value of `"default"`), the flag bits are unset. The escape-generating methods now consult these flags to decide whether colors should be set based on the color bits in `attr` or the terminal's 'default' fg/bg colors should be used.

### Some Caveats

 - I added 16 bits to the `attr` size but am only using two of them at the moment so it's a bit on the wasteful side. Unless you can imagine a use for the rest of that space, it might make more sense to set `ScreenBuffer.prototype.ATTR_SIZE` to `5` rather than `6`. I believe that the rest of the code should adapt without error if you just change this one value.

- Since the _generateDeltaEscapeSequence()_ method may need to set the fg and bg colors back to the 'default' value independently I added the `defaultColor` and `bgDefaultColor` escapes to `term.optimized`.

- I incremented the version number on `.sbuf` files to 3 but ended up modifying the _load-_ and _saveSyncV2()_ methods to branch based on the version number in the header rather than creating brand new (and nearly identical) V3 methods. If keeping the historical serialization formats in the source is important to you, you might want to paste the old versions back in.

- I used the `demo/spaceship.js` script as my main test-case and made some minor edits to it in places where it was relying on a black `bgColor` being present by default.

- I wasn't quite sure if the `object2attr` and `attr2object` definitions were repeated intentionally or not (since the implementations appeared identical). For now I'm just assigning the same function to both the 'class' and 'instance' methods...