### PR TITLE
fix for default → non-default color changes

### DIFF
--- a/lib/ScreenBuffer.js
+++ b/lib/ScreenBuffer.js
@@ -1171,7 +1171,7 @@ ScreenBuffer.prototype.generateDeltaEscapeSequence = function generateDeltaEscap
 	{
 		if ( ! ( lastAttr & FG_DEFAULT_COLOR ) ) { esc += term.optimized.defaultColor ; }
 	}
-	else if ( color !== lastColor )
+	else if ( color !== lastColor || ( lastAttr & FG_DEFAULT_COLOR ) )
 	{
 		esc += term.optimized.color256[ color ] ;
 	}
@@ -1180,7 +1180,7 @@ ScreenBuffer.prototype.generateDeltaEscapeSequence = function generateDeltaEscap
 	{
 		if ( ! ( lastAttr & BG_DEFAULT_COLOR ) ) { esc += term.optimized.bgDefaultColor ; }
 	}
-	else if ( bgColor !== lastBgColor )
+	else if ( bgColor !== lastBgColor || ( lastAttr & BG_DEFAULT_COLOR ) )
 	{
 		esc += term.optimized.bgColor256[ bgColor ] ;
 	}


### PR DESCRIPTION
There seems to be a rendering bug when cells in the buffer go from a 'default' color back to a 256-palette color. Rather than the default color being used only where requested, it ends up 'leaking' into the following cells.

Compare these two scripts (which differ only in the `sb.put` line at the bottom):

```js
var termkit = require( 'terminal-kit' ),
    term = termkit.terminal;

var sb = termkit.ScreenBuffer.create({
    dst:term, x:1, y:1, width:40, height:10, noFill:true
})
sb.fill({attr:{
    bgColor:'black'
}})

sb.put({x:5, y:4, attr:{color:'magenta'}}, 'florid prose')
sb.draw()
```
----------------------------------------
```js
var termkit = require( 'terminal-kit' ),
    term = termkit.terminal;

var sb = termkit.ScreenBuffer.create({
    dst:term, x:1, y:1, width:40, height:10, noFill:true
})
sb.fill({attr:{
    bgColor:'black'
}})

sb.put({x:5, y:4, attr:{color:'magenta', bgDefaultColor:true}}, 'florid prose')
sb.draw()
```

In the second example (where `bgDefaultColor:true` has been set), the default color ends up overflowing the text that's been `put` into the buffer and overwrites the remaining rows & columns):
![default-bg-overflow](https://cloud.githubusercontent.com/assets/469523/26764176/fab97be6-492f-11e7-9284-dee5aeaff110.png)

The fix is to simply compare the current `attr`'s default-ness to the previous cell's and emit the proper escape if there's been a change.
