### PR TITLE
Option to use singleColumnMenu instead of singleLineMenu in inputField

### DIFF
--- a/lib/inputField.js
+++ b/lib/inputField.js
@@ -364,8 +364,11 @@ module.exports = function inputField( options , callback )
 	// Compute the coordinate of the end of a string, given a start coordinate
 	var autoCompleteMenu = ( menu ) => {
 		paused = true ;
-		
-		this.singleLineMenu( menu , dynamic.autoCompleteMenu , ( error , response ) => {
+
+		var useSingleColumnMenu = true ;
+		var menuBuilderFn = useSingleColumnMenu ? this.singleColumnMenu.bind(this) : this.singleLineMenu.bind(this) ;
+
+		menuBuilderFn( menu , dynamic.autoCompleteMenu , ( error , response ) => {
 			// Unpause unconditionnally
 			paused = false ;
 			if ( error ) { return ; }
@@ -390,13 +393,22 @@ module.exports = function inputField( options , callback )
 			if ( echo )
 			{
 				// Erase the menu
-				this.column.eraseLineAfter( 1 ) ;
+				if ( ! useSingleColumnMenu ) {
+					this.column.eraseLineAfter( 1 ) ;
+				}
 				
 				// If the input field was ending on the last line, we need to move it one line up
-				if ( end.y >= this.height && start.y > 1 ) { start.y -- ; }
+				while ( end.y >= this.height && start.y > 1 ) { 
+					start.y -- ; 
+				}
 				
 				computeAllCoordinate() ;
 				redraw() ;
+
+				if ( useSingleColumnMenu ) {
+					this.moveTo( cursor.x , cursor.y+1 ) ;
+					this.column.eraseDisplayBelow( ) ;
+				}
 				this.moveTo( cursor.x , cursor.y ) ;
 			}
 			

--- a/sample/input-field-column-menu.js
+++ b/sample/input-field-column-menu.js
@@ -1,0 +1,68 @@
+var term = require( 'terminal-kit' ).terminal;
+
+var OPTIONS = [
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+  'Lorem iaculis risus non libero efficitur lobortis.',
+  'Lorem sem sem, mollis vitae mi eget, lacinia semper felis.',
+  'Lorem finibus felis vitae ante volutpat tristique. In hac habitasse platea dictumst.'
+];
+
+term.bold.green('Test: ');
+term.inputField({
+    // autoComplete: commands,
+    autoComplete: function (text) {
+      var optionsStartingWith = getOptionsStartingWith(text)
+      if (optionsStartingWith.length > 1) {
+        var commonInitialSubstring =  getCommonInitialSubstring(optionsStartingWith)
+        if (commonInitialSubstring !== text) {
+          return commonInitialSubstring;
+        }
+      }
+      var optionsContaining = getOptionsContaining(text)
+      if (optionsContaining.length === 0) {
+        return text
+      }
+      return optionsContaining.length === 1 ? optionsContaining[0] : optionsContaining;
+    },
+    autoCompleteMenu: true,
+    autoCompleteHint: true,
+  },
+  function(error, input) {
+    term.green("\nSelected: '%s'\n" , input);
+    process.exit() ;
+  }
+);
+
+function getOptionsStartingWith(text) {
+  return OPTIONS.filter(function(cmd) { 
+    return cmd.startsWith(text);
+  })
+}
+
+function getOptionsContaining(text) {
+  return OPTIONS.filter(function(cmd) {
+    return cmd.toLowerCase().includes(text.toLowerCase());
+  })
+}
+
+function getCommonInitialSubstring(commands) {
+  if (commands.length === 0) return '';
+  if (commands.length === 1) return commands[0];
+
+  var commonInitialSubstring = []
+  var index = 0
+  for (var index = 0; index < commands[0].length ; index++) {
+    var char = commands[0].charAt(index)
+    if (commands.some(hasDifferentCharAtIndex(char, index))) {
+      break;
+    }
+    commonInitialSubstring.push(char);
+  }
+  return commonInitialSubstring.join('');
+}
+
+function hasDifferentCharAtIndex(char, index) {
+  return function(text) {
+    return index >= text.length || text.charAt(index) !== char;
+  }
+}


### PR DESCRIPTION
This is a proof of concept for using `singleColumnMenu` instead of `singleLineMenu` in `inputField`. Note that the flag to choose the menu type is initially hard coded.

To run the sample: `node sample/input-field-column-menu.js`