### PR TITLE
Allow for synchronous repositioning of inputField

### DIFF
--- a/lib/inputField.js
+++ b/lib/inputField.js
@@ -976,22 +976,24 @@ module.exports = function inputField( options , callback )
 		echo = false ;
 		
 		this.getCursorLocation( ( error , x , y ) => {
-			
 			if ( error ) { cleanup( error ) ; return ; }
-			
-			start.x = x ;
-			start.y = y ;
-			
-			if ( options.echo )
-			{
-				echo = true ;
-				computeAllCoordinate() ;
-				redraw() ;
-			}
-			
+			if ( options.echo ) { echo = true ; }
 			controller.emit( 'rebased' ) ;
 		} ) ;
 	} ;
+
+	// Move the input field to given coordinates
+	controller.reposition = ( x , y ) => {
+		start.x = x ;
+		start.y = y ;
+
+		if ( options.echo )
+		{
+			computeAllCoordinate() ;
+			redraw() ;
+		}
+	} ;
+
 	
 	// Init the input field
 	init() ;


### PR DESCRIPTION
I've run into problems when using the existing `rebase` method as part of a `resize` event handler. In particular, the asynchronous nature of rebase means that it will end up in a race condition with the rapid sequence of resize events that are emitted when the user is dragging the edges of the terminal window.

I'm not sure what the ideal API for this would be (I could also imagine naming it `setPosition` or instead adding optional `x` & `y` arguments to rebase and having it omit the `getCursorLocation` step if they're provided). But regardless of the naming scheme, this would be useful functionality for my full-screen-redraw use case...