### PR TITLE
Allow Escape key to substitute for Alt

### DIFF
--- a/doc/high-level.md
+++ b/doc/high-level.md
@@ -355,6 +355,8 @@ Available actions are:
 * startOfInput: move the cursor at the begining of input (default: HOME)
 * endOfInput: move the cursor at the end of input (default: END)
 * autoComplete: auto-complete the input (default: TAB)
+* meta: if bound to ESCAPE, allows for two-key combos like ESC-D to generate an ALT_D 
+  (useful for terminals that do not have a modifier key assigned to alt/meta)
 
 It returns an EventEmitter object featuring some functions to control things during the input process:
 

--- a/lib/inputField.js
+++ b/lib/inputField.js
@@ -149,7 +149,7 @@ module.exports = function inputField( options , callback )
 		start = {} , end = {} , cursor = {} , endHint = {} ,
 		inputs = [] , inputIndex ,
 		alwaysRedraw = options.tokenHook || options.autoCompleteHint ,
-		hint = [] ;
+		hint = [] , meta = false ;
 	
 	var dynamic = {
 		style: options.style || this ,
@@ -509,6 +509,15 @@ module.exports = function inputField( options , callback )
 		
 		var leftPart , autoCompleted , extraLines , lastOffset = offset , cutOffset ;
 		
+		// if previous keystroke triggered the 'meta' keybinding, prepend ALT_ to this key
+		if ( meta )
+		{
+			var altkey = 'ALT_' + key.toUpperCase() ;
+			if ( data ) { data.isCharacter = false ; }
+			if ( keyBindings[altkey] ) { key = altkey ; }
+		}
+		meta = false ;
+
 		if ( data && data.isCharacter )
 		{
 			// if data.isCharacter, this is a regular UTF-8 character, not a special key
@@ -552,6 +561,10 @@ module.exports = function inputField( options , callback )
 				
 				case 'cancel' :
 					if ( options.cancelable ) { cleanup() ; }
+					break ;
+
+				case 'meta' :
+					meta = true ;
 					break ;
 				
 				case 'backDelete' :


### PR DESCRIPTION
Since many terminals don't default to using the alt/option key as a Meta modifier, it would be nice if inputField allowed for ESC to be used for meta-keybindings in these circumstances (see emacs or Readline-powered command line tools for examples of this behavior). 

Since this is incompatible with the default of using ESC as a 'cancel' keybinding, I'd propose adding an optional keybinding called 'meta' that could be assigned to ESCAPE as seen below:

```js
var termkit = require( './lib/termkit' ),
    term = termkit.terminal;

var keys = {
    ESCAPE:'meta',
    ENTER:'submit', KP_ENTER:'submit',
    DELETE:'delete', BACKSPACE:'backDelete',
    RIGHT:'forward', LEFT:'backward',
    ALT_F:'nextWord', ALT_B:'previousWord',
    ALT_D:'deleteNextWord', ALT_BACKSPACE:'deletePreviousWord',
};

term.inputField({
  keyBindings:keys, default:"try hitting ESCAPE then the B or BACKSPACE key"
}, function(input){
  term.processExit(0)
})
```