### PR TITLE
Add windows terminal detection

### DIFF
--- a/lib/detectTerminal.js
+++ b/lib/detectTerminal.js
@@ -157,19 +157,34 @@ exports.getParentTerminalInfo = function getParentTerminalInfo( callback )
 	var t256color = ( process.env.TERM && process.env.TERM.match( /256/ ) ) ||
 		( process.env.COLORTERM && process.env.COLORTERM.match( /256/ ) ) ;
 	var tTrueColor = process.env.COLORTERM && process.env.COLORTERM.match( /^(truecolor|24bits?)$/ ) ;
-	
+
+	var ppidCommand = 'ps -o ppid -h -p {0}';
+	var ppnameCommand = 'ps -o comm -h -p {0}';
+	if(process.platform == "win32"){
+		ppidCommand = 'wmic process where processid={0} get parentprocessid';
+		ppnameCommand = 'wmic process where processid={0} get name';
+	}
+
 	async.do( [
 		function( asyncCallback ) {
-			exec( 'ps -h -o ppid -p ' + pid , function( error , stdout ) {
+			exec(ppidCommand.replace('{0}',pid), function( error , stdout ) {
 				if ( error ) { asyncCallback( error ) ; return ; }
-				pid = parseInt( stdout ) ;
+				if(process.platform == "win32"){
+					pid = stdout.toString().split('\n')[1].trim();
+				}else{
+					pid = parseInt( stdout ) ;
+				}
 				asyncCallback() ;
 			} ) ;
 		} ,
 		function( asyncCallback ) {
-			exec( 'ps -h -o comm -p ' + pid , function( error , stdout ) {
+			exec( ppnameCommand.replace('{0}',pid), function( error , stdout ) {
 				if ( error ) { asyncCallback( error ) ; return ; }
-				appName = stdout.trim() ;
+				if(process.platform == "win32"){
+					appName = stdout.toString().split('\n')[1].trim();
+				}else{
+					appName = stdout.trim() ;
+				}
 				asyncCallback() ;
 			} ) ;
 		}
@@ -233,6 +248,16 @@ exports.getParentTerminalInfo = function getParentTerminalInfo( callback )
 				appName = 'Eterm' ;
 				appId = t256color || tTrueColor ? 'eterm-256color' : 'eterm' ;
 				break ;
+			case 'bash.exe':
+				//TODO: might be ok with the xterm profile or might create one for bash
+				appName = 'xterm' ;
+				appId = 'xterm-256color';
+				break;
+			case 'cmd.exe':
+			case 'powershell.exe':
+				//TODO: create a profile for cmd and powershell
+				//Setting to 0 to force it to throw terminal not found until profile is created
+				pid = 0;
 			default :
 				
 				if ( appName.match( /gnome-terminal/ ) )

--- a/lib/detectTerminal.js
+++ b/lib/detectTerminal.js
@@ -170,7 +170,7 @@ exports.getParentTerminalInfo = function getParentTerminalInfo( callback )
 			exec(ppidCommand.replace('{0}',pid), function( error , stdout ) {
 				if ( error ) { asyncCallback( error ) ; return ; }
 				if(process.platform == "win32"){
-					pid = stdout.toString().split('\n')[1].trim();
+					pid = parseInt(stdout.toString().split('\n')[1].trim());
 				}else{
 					pid = parseInt( stdout ) ;
 				}


### PR DESCRIPTION
@cronvel I was able to figure out a way to detect windows terminals. At least the ones that I am using. I think since msys is a fork of cygwin and both use bash we are probably ok with just the 3 options.

This is not complete yet so I wouldn't merge it until we figure the whole issue out. There is one unsolved question for me. What do we do if the user is calling node with winpty? The parent process thing will just dead end with winpty.exe as far as I can tell. I also know somethings are weird when used with winpty.

I am fairly certain we will need to create a profile for each one of these. I could try copying the xterm256 profile and modifying it as needed for bash. Seems like it might take a very long time though :). Any suggestions on how to accomplish this would be helpful.

Let me know what you think about these changes.
Some additional things to do if we know we are not in cmd or powershell would be to try the uname -o command. In my case it returns "Msys". I think we only need to do this though if we decide that the same profile does not work for all cygwin like windows terminals. I believe they all use mintty by default.