### PR TITLE
Use stdout columns/rows properties for terminal size

### DIFF
--- a/lib/Terminal.js
+++ b/lib/Terminal.js
@@ -860,11 +860,8 @@ function bgColorRgbHandler( r , g , b ) {
 // Called by either SIGWINCH signal or stdout's 'resize' event.
 // It is not meant to be used by end-user.
 function onResize() {
-	if ( this.stdout.getWindowSize ) {
-		var windowSize = this.stdout.getWindowSize() ;
-		this.width = windowSize[ 0 ] ;
-		this.height = windowSize[ 1 ] ;
-	}
+	this.width = this.stdout.columns ;
+	this.height = this.stdout.rows ;
 
 	this.emit( 'resize' , this.width , this.height ) ;
 }


### PR DESCRIPTION
The `getWindowSize` method is deprecated in Node.js and is no longer available in the documentation. In the core the method is still available for backwards compatibility, but is essentially a wrapper around `stdout.columns` and `stdout.rows` values - please see [implementation in lib/tty.js](https://github.com/nodejs/node/blob/1e8d110e640c658e4f6ed7540db62d063269ba6c/lib/tty.js#L206).

This then allows to use a custom stdout write stream for a terminal (other than the default `process.stdout`) without implementing this legacy method.