### PR TITLE
add: link to replit run

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,2 +1,2 @@
 language = "nodejs"
-run = "npm install && cd demo && node spaceship.js"
+run = "yarn install && yarn link && cd sample && yarn link terminal-kit && cd ../demo && node spaceship.js"

--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm install && cd demo && node spaceship.js"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![License](https://img.shields.io/github/license/cronvel/terminal-kit.svg)](https://github.com/cronvel/terminal-kit)
 [![Downloads](https://img.shields.io/npm/dm/terminal-kit.svg)](https://www.npmjs.com/package/terminal-kit)
 [![Version](https://img.shields.io/npm/v/terminal-kit.svg)](https://www.npmjs.com/package/terminal-kit)
+[![run on repl.it](http://repl.it/badge/github/cronvel/terminal-kit)](https://repl.it/github/cronvel/terminal-kit)
 
 [![Stats](https://nodei.co/npm/terminal-kit.png?downloads=true&downloadRank=true&stars=true)](https://www.npmjs.com/package/terminal-kit)
 


### PR DESCRIPTION
i think it would be pretty cool to let people see how this code works (and edit / preview the program) right in their browser, without any manual downloads or installation. i'm thinking we can add a 'run on repl.it' button, which redirects to something like [this](https://repl.it/@eankeen/run-terminal-kit):

![image](https://i.imgur.com/5ryVYxr.png)
