### PR TITLE
Adjust single line menu

### DIFF
--- a/lib/singleLineMenu.js
+++ b/lib/singleLineMenu.js
@@ -123,6 +123,11 @@ module.exports = function singleLineMenu( menuItems_ , options , callback ) {
 					itemWidth = max - endX ;
 					displayText = termkit.truncateString( menuItems[ i ] , itemWidth - 1 ) + '…' ;
 
+					if ( i === selectedIndex ) {
+						selectedPage = p ;
+						selectedIndex = menuPages[p].length ;
+					}
+
 					menuPages[ p ].push( {
 						index: i ,
 						text: menuItems[ i ] ,
@@ -130,6 +135,7 @@ module.exports = function singleLineMenu( menuItems_ , options , callback ) {
 						displayTextWidth: itemWidth ,
 						x: endX
 					} ) ;
+
 
 					p ++ ;
 					endX = 1 + previousPageHintWidth ;
@@ -143,6 +149,11 @@ module.exports = function singleLineMenu( menuItems_ , options , callback ) {
 					i -- ;
 					continue ;
 				}
+			}
+
+			if ( i === selectedIndex ) {
+				selectedPage = p ;
+				selectedIndex = menuPages[p].length ;
 			}
 
 			menuPages[ p ].push( {

--- a/lib/singleLineMenu.js
+++ b/lib/singleLineMenu.js
@@ -87,6 +87,7 @@ module.exports = function singleLineMenu( menuItems_ , options , callback ) {
 	if ( options.previousPageHint === undefined ) { options.previousPageHint = ' « ' ; }
 	if ( ! options.style ) { options.style = this ; }
 	if ( ! options.selectedStyle ) { options.selectedStyle = this.dim.blue.bgGreen ; }
+	if ( ! options.centered ) { options.centered = false ; }
 
 	if ( ! options.y ) { this( '\n' ) ; }
 	else { this.moveTo( 1 , options.y ) ; }
@@ -205,6 +206,20 @@ module.exports = function singleLineMenu( menuItems_ , options , callback ) {
 
 		this.moveTo.eraseLineAfter( start.x , start.y ) ;
 
+		const lineWidth = (
+			( selectedPage && previousPageHintWidth || 0 ) +
+      ( selectedPage < menuPages.length - 1 && nextPageHintWidth || 0 ) +
+      menuPages[ selectedPage ].reduce( ( width , item ) => width + item.displayTextWidth , 0 ) +
+      ( ( menuPages[ selectedPage ].length - 1 ) * separatorWidth )
+		) ;
+
+		const edgeSpace = options.centered
+			? Math.floor( ( this.width - lineWidth ) / 2 )
+			: 0 ;
+
+		options.style.forceStyleOnReset.noFormat( ' '.repeat( edgeSpace ) ) ;
+		endX += edgeSpace ;
+
 		if ( selectedPage ) {
 			options.style.forceStyleOnReset.noFormat( options.previousPageHint ) ;
 			endX += previousPageHintWidth ;
@@ -230,6 +245,11 @@ module.exports = function singleLineMenu( menuItems_ , options , callback ) {
 		if ( selectedPage < menuPages.length - 1 ) {
 			options.style.forceStyleOnReset.noFormat( options.nextPageHint ) ;
 			endX += nextPageHintWidth ;
+		}
+
+		if ( options.centered ) {
+			options.style.forceStyleOnReset.insert( ( edgeSpace && edgeSpace + 1 ) || 0 ) ;
+			endX += edgeSpace ;
 		}
 
 		this.column( cursorX ) ;

--- a/sample/single-line-menu-test.js
+++ b/sample/single-line-menu-test.js
@@ -29,10 +29,10 @@
 
 
 
-require( '../lib/termkit.js' ).getDetectedTerminal( function( error , term ) {
+require( '../lib/termkit.js' ).getDetectedTerminal( ( error , term ) => {
 
 	term.grabInput( { mouse: 'motion' } ) ;
-	
+
 	var items = [
 		'汉字汉字汉字汉字汉字汉字汉字汉字' , '汉字汉字汉字汉字汉字汉字汉字汉字' ,
 		'File' , 'Edit' , 'View' , 'History' , 'Bookmarks' , 'Tools' , 'Help' ,
@@ -40,60 +40,78 @@ require( '../lib/termkit.js' ).getDetectedTerminal( function( error , term ) {
 		'汉字汉字汉字汉字汉字汉字汉字汉字汉字汉字汉字汉字汉字汉字汉字汉字汉字汉字汉字汉字汉字汉字汉字汉字' ,
 		'汉字汉字汉字汉字汉字汉字汉字汉字' , '汉字汉字汉字汉字汉字汉字汉字汉字' , '汉字汉字汉字汉字汉字汉字汉字汉字' , '汉字汉字汉字汉字汉字汉字汉字汉字' , '汉字汉字汉字汉字汉字汉字汉字汉字'
 	] ;
-	
-	function menu()
-	{
+
+	function menu() {
 		var options = {
 			y: 1 ,
 			style: term.inverse ,
 			selectedStyle: term.dim.blue.bgGreen
 		} ;
-		
-		var menu_ = term.singleLineMenu( items , options , function( error , response ) {
-			
-			if ( error )
-			{
+
+		term.singleLineMenu( items , options , ( error2 , response ) => {
+			if ( error2 ) {
 				term.red.bold( "\nAn error occurs: " + error + "\n" ) ;
 				terminate() ;
 				return ;
 			}
-			
+
 			term.green( "\n#%s selected: %s (%s,%s)\n" , response.selectedIndex , response.selectedText , response.x , response.y ) ;
 			terminate() ;
 		} ) ;
-		
+
 		//menu_.on( 'highlight' , eventData => console.error( '\neventData:' , eventData ) ) ;
 	}
-	
-	
-	
-	async function asyncMenu()
-	{
+
+	function menuStartingOnSecondPage() {
+		var options = {
+			y: 1 ,
+			selectedIndex: 8 ,
+			style: term.inverse ,
+			selectedStyle: term.dim.blue.bgGreen
+		} ;
+
+		term.singleLineMenu( items , options , ( error2 , response ) => {
+			if ( error2 ) {
+				term.red.bold( "\nAn error occurs: " + error + "\n" ) ;
+				terminate() ;
+				return ;
+			}
+
+			term.green( "\n#%s selected: %s (%s,%s)\n" , response.selectedIndex , response.selectedText , response.x , response.y ) ;
+			terminate() ;
+		} ) ;
+	}
+
+	async function menuAsync() {
 		var options = {
 			y: 1 ,
 			style: term.inverse ,
 			selectedStyle: term.dim.blue.bgGreen
 		} ;
-		
+
 		var response = await term.singleLineMenu( items , options ).promise ;
 		term.green( "\n#%s selected: %s (%s,%s)\n" , response.selectedIndex , response.selectedText , response.x , response.y ) ;
 		terminate() ;
 	}
-	
-	
-	
-	function terminate()
-	{
+
+	function terminate() {
 		term.grabInput( false ) ;
 		// Add a 100ms delay, so the terminal will be ready when the process effectively exit, preventing bad escape sequences drop
-		setTimeout( function() { process.exit() ; } , 100 ) ;
+		setTimeout( () => { process.exit() ; } , 100 ) ;
 	}
-	
+
 	term.clear() ;
 	term.bold.cyan( '\n\nSelect one item from the menu!' ) ;
 
-	menu() ; 
-	//asyncMenu() ; 
+	switch ( process.argv[2] ) {
+		case 'menuSecondPage' :
+			menuStartingOnSecondPage() ;
+			break ;
+		case 'menuAsync' :
+			menuAsync() ;
+			break ;
+		default :
+			menu() ;
+			break ;
+	}
 } ) ;
-
-

--- a/sample/single-line-menu-test.js
+++ b/sample/single-line-menu-test.js
@@ -62,6 +62,28 @@ require( '../lib/termkit.js' ).getDetectedTerminal( ( error , term ) => {
 		//menu_.on( 'highlight' , eventData => console.error( '\neventData:' , eventData ) ) ;
 	}
 
+	function menuCentered() {
+		var options = {
+			y: 1 ,
+			centered: true ,
+			style: term.inverse ,
+			selectedStyle: term.dim.blue.bgGreen
+		} ;
+
+		term.singleLineMenu( items , options , ( error2 , response ) => {
+			if ( error2 ) {
+				term.red.bold( "\nAn error occurs: " + error + "\n" ) ;
+				terminate() ;
+				return ;
+			}
+
+			term.green( "\n#%s selected: %s (%s,%s)\n" , response.selectedIndex , response.selectedText , response.x , response.y ) ;
+			terminate() ;
+		} ) ;
+
+		//menu_.on( 'highlight' , eventData => console.error( '\neventData:' , eventData ) ) ;
+	}
+
 	function menuStartingOnSecondPage() {
 		var options = {
 			y: 1 ,
@@ -104,6 +126,9 @@ require( '../lib/termkit.js' ).getDetectedTerminal( ( error , term ) => {
 	term.bold.cyan( '\n\nSelect one item from the menu!' ) ;
 
 	switch ( process.argv[2] ) {
+		case 'menuCentered' :
+			menuCentered() ;
+			break ;
 		case 'menuSecondPage' :
 			menuStartingOnSecondPage() ;
 			break ;


### PR DESCRIPTION
I made some personal edits, I wanted to share in case you were interested. Two changes, in addition to some general tweaks on the `sample/single-line-menu-test` file as my linter was unhappy.

1) Added `centered` as an option to the `singleLineMenu` method. When passed, this will attempt to fill in space before/after the menu, keeping the styling the same so the background is consistent across the entire line.
2) Fixed bug with `singleLineMenu` method. If `selectedIndex` was passed as an option but the relevant menu item would be after the first page it would throw an error. This was due to `selectedPage` not being set to anything other than `0` during the first call of `emitHighlight`.

`sample/single-line-menu-test.js` was updated to include an example case for setting a `selectedIndex` and centering the menu. Not important to include though.