### PR TITLE
Added configurable option to allow stubbing with testing frameworks

### DIFF
--- a/lib/Terminal.js
+++ b/lib/Terminal.js
@@ -322,7 +322,7 @@ Terminal.create = function createTerminal( createOptions ) {
 				fn.options = chainOptions ;
 
 				// Replace the getter by the newly created function, to speed up further call
-				Object.defineProperty( this , key , { value: fn } ) ;
+				Object.defineProperty( this , key , { value: fn, configurable: true } ) ;
 
 				//console.log( 'Create function:' , key ) ;
 


### PR DESCRIPTION
Set the configurable property to true to allow testing frameworks such as sinon to stub the terminal object. By default this is set to false ([ref](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty)).