### PR TITLE
initial osx terminal

### DIFF
--- a/lib/detectTerminal.js
+++ b/lib/detectTerminal.js
@@ -30,6 +30,7 @@
 
 const Promise = require( 'seventh' ) ;
 const exec = require( 'child_process' ).exec ;
+const basename = require( 'path' ).basename ;
 
 const termkit = require( './termkit.js' ) ;
 
@@ -148,8 +149,6 @@ exports.guessTerminal = function( unpipe ) {
 	} ;
 } ;
 
-
-
 function getParentProcess( pid ) {
 	var parentPid , appName ;
 
@@ -157,7 +156,9 @@ function getParentProcess( pid ) {
 		exec( 'ps -h -o ppid -p ' + pid , ( error , stdout ) => {
 			if ( error ) { reject( error ) ; return ; }
 
-			parentPid = parseInt( stdout , 10 ) ;
+			let { 0: foundPid } = stdout.match(  /.*([0-9]+)/gm ) ;
+			if( ! foundPid ) throw new Error( "couldn't get parent PID" ) ;
+			parentPid = parseInt( foundPid , 10 ) ;
 
 			exec( 'ps -h -o comm -p ' + parentPid , ( error_ , stdout_ ) => {
 				if ( error_ ) { reject( error_ ) ; return ; }
@@ -187,11 +188,15 @@ exports.getParentTerminalInfo = async function( callback ) {
 
 	try {
 		loopAgain = true ;
+		let appSet = new Set() ;
 
 		while ( loopAgain ) {
 			( { appName , pid } = await getParentProcess( pid ) ) ;
 
 			//console.log( 'found:' , appName , pid ) ;
+
+			appName = basename( appName ) ;
+			appSet.add( appName ) ;
 
 			// Do NOT skip the first, there are case where the terminal may run directly node.js without any shell in between
 			//if ( ++ loop <= 1 ) { asyncCallback( undefined , true ) ; return ; }
@@ -199,6 +204,11 @@ exports.getParentTerminalInfo = async function( callback ) {
 			loopAgain = false ;
 
 			switch ( appName ) {
+				case 'iTerm' :
+				case 'iTerm2' :
+				case 'Terminal' :
+					appId = 'osx-256color' ;
+					break ;
 				case 'linux' :
 				case 'xterm' :
 				case 'konsole' :
@@ -254,7 +264,7 @@ exports.getParentTerminalInfo = async function( callback ) {
 						break ;
 					}
 
-					if ( ! pid || pid === 1 ) { throw new Error( 'Terminal not found' ) ; }
+					if ( ! pid || pid === 1 ) { throw new Error( 'Terminal(s) not found: ' + [ ... appSet ].join( ', ' ) ) ; }
 					loopAgain = true ;
 			}
 		}

--- a/lib/termconfig/osx-256color.js
+++ b/lib/termconfig/osx-256color.js
@@ -1,0 +1,180 @@
+/*
+    Terminal Kit
+
+    Copyright (c) 2009 - 2020 Cédric Ronvel
+
+    The MIT License (MIT)
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+
+"use strict" ;
+
+const tree = require( 'tree-kit' ) ;
+const xterm256 = require( './xterm-256color.js' ) ;
+const xtermGeneric = require( './xterm.generic.js' ) ;
+
+const keymap = {
+	UP: '\x1b[B' ,
+	DOWN: '\x1b[A' ,
+	RIGHT: '\x1b[C' ,
+	LEFT: '\x1b[D' ,
+	DELETE: '\x7f' ,
+	SHIFT_F1: '\x1b[1;2P' ,
+	SHIFT_F2: '\x1b[1;2Q' ,
+	SHIFT_F3: '\x1b[1;2R' ,
+	SHIFT_F4: '\x1b[1;2S' ,
+	CTRL_F1: '\x1bOP' ,
+	CTRL_F2: '\x1bOQ' ,
+	CTRL_F3: '\x1bOR' ,
+	CTRL_F4: '\x1bOS' ,
+	CTRL_F5: '\x1b[15~' ,
+	CTRL_F6: '\x1b[17~' ,
+	CTRL_F7: '\x1b[18~' ,
+	CTRL_F8: '\x1b[19~' ,
+	CTRL_F9: '\x1b[20~' ,
+	CTRL_F10: '\x1b[21~' ,
+	CTRL_F11: '\x1b[23~' ,
+	CTRL_F12: '\x1b[24~' ,
+	CTRL_SHIFT_F1: '\x1bOP' ,
+	CTRL_SHIFT_F2: '\x1bOQ' ,
+	CTRL_SHIFT_F3: '\x1bOR' ,
+	CTRL_SHIFT_F4: '\x1bOS' ,
+	CTRL_SHIFT_F5: '\x1b[15~' ,
+	CTRL_SHIFT_F6: '\x1b[17~' ,
+	CTRL_SHIFT_F7: '\x1b[18~' ,
+	CTRL_SHIFT_F8: '\x1b[19~' ,
+	CTRL_SHIFT_F9: '\x1b[20~' ,
+	CTRL_SHIFT_F10: '\x1b[21~' ,
+	CTRL_SHIFT_F11: '\x1b[23~' ,
+	CTRL_SHIFT_F12: '\x1b[24~' ,
+	ALT_UP: '\x1b\x1b[A' ,
+	ALT_DOWN: '\x1b\x1b[B' ,
+	ALT_RIGHT: '\x1b\x1b[C' ,
+	ALT_LEFT: '\x1b\x1b[D' ,
+	SHIFT_DELETE: '\x7f' ,
+	ALT_BACKSPACE: '\x7f' ,
+	ALT_TAB: '\x09' ,
+	CTRL_ALT_SPACE: ' ' ,
+	ALT_A: '\xc3\xa5' ,
+	CTRL_ALT_A: '\x01' ,
+	ALT_SHIFT_A: '\xc3\x85' ,
+	ALT_B: '\xe2\x88\xab' ,
+	CTRL_ALT_B: '\x02' ,
+	ALT_SHIFT_B: '\xc4\xb1' ,
+	ALT_C: '\xc3\xa7' ,
+	CTRL_ALT_C: '\x03' ,
+	ALT_SHIFT_C: '\xc3\x87' ,
+	ALT_D: '\xe2\x88\x82' ,
+	CTRL_ALT_D: '\x04' ,
+	ALT_SHIFT_D: '\xc3\x8e' ,
+	ALT_E: '\xc2\xb4' ,
+	CTRL_ALT_E: '\x05' ,
+	ALT_SHIFT_E: '\xc2\xb4' ,
+	ALT_F: '\xc6\x92' ,
+	CTRL_ALT_F: '\x06' ,
+	ALT_SHIFT_F: '\xc3\x8f' ,
+	ALT_G: '\xc2\xa9' ,
+	CTRL_ALT_G: '\x07' ,
+	ALT_SHIFT_G: '\xcb\x9d' ,
+	ALT_H: '\xcb\x99' ,
+	CTRL_ALT_H: '\x08' ,
+	ALT_SHIFT_H: '\xc3\x93' ,
+	ALT_I: '\xcb\x86' ,
+	CTRL_ALT_I: '\x09' ,
+	ALT_SHIFT_I: '\xcb\x86' ,
+	ALT_J: '\xe2\x88\x86' ,
+	CTRL_ALT_J: '\x0a' ,
+	ALT_SHIFT_J: '\xc3\x94' ,
+	ALT_K: '\xcb\x9a' ,
+	CTRL_ALT_K: '\x0b' ,
+	ALT_SHIFT_K: '\xef\xa3\xbf' ,
+	ALT_L: '\xc2\xac' ,
+	CTRL_ALT_L: '\x0c' ,
+	ALT_SHIFT_L: '\xc3\x92' ,
+	ALT_M: '\xc2\xb5' ,
+	ALT_SHIFT_M: '\xc3\x82' ,
+	ALT_N: '\xcb\x9c' ,
+	CTRL_ALT_N: '\x0e' ,
+	ALT_SHIFT_N: '\xcb\x9c' ,
+	ALT_O: '\xc3\xb8' ,
+	CTRL_ALT_O: '\x0f' ,
+	ALT_SHIFT_O: '\xc3\x98' ,
+	ALT_P: '\xcf\x80' ,
+	CTRL_ALT_P: '\x10' ,
+	ALT_SHIFT_P: '\xe2\x88\x8f' ,
+	ALT_Q: '\xc5\x93' ,
+	CTRL_ALT_Q: '\x11' ,
+	ALT_SHIFT_Q: '\xc5\x92' ,
+	ALT_R: '\xc2\xae' ,
+	CTRL_ALT_R: '\x12' ,
+	ALT_SHIFT_R: '\xe2\x80\xb0' ,
+	ALT_S: '\xc3\x9f' ,
+	CTRL_ALT_S: '\x13' ,
+	ALT_SHIFT_S: '\xc3\x8d' ,
+	ALT_T: '\xe2\x80\xa0' ,
+	CTRL_ALT_T: '\x14' ,
+	ALT_SHIFT_T: '\xcb\x87' ,
+	ALT_U: '\xc2\xa8' ,
+	CTRL_ALT_U: '\x15' ,
+	ALT_SHIFT_U: '\xc2\xa8' ,
+	ALT_V: '\xe2\x88\x9a' ,
+	CTRL_ALT_V: '\x16' ,
+	ALT_SHIFT_V: '\xe2\x97\x8a' ,
+	ALT_W: '\xe2\x88\x91' ,
+	ALT_SHIFT_W: '\xe2\x80\x9e' ,
+	ALT_X: '\xe2\x89\x88' ,
+	CTRL_ALT_X: '\x18' ,
+	ALT_SHIFT_X: '\xcb\x9b' ,
+	ALT_Y: '\\' ,
+	CTRL_ALT_Y: '\x19' ,
+	ALT_SHIFT_Y: '\xc3\x81' ,
+	ALT_Z: '\xce\xa9' ,
+	CTRL_ALT_Z: '\x1a' ,
+	ALT_SHIFT_Z: '\xc2\xb8'
+} ;
+
+// Copied from xterm-256color.generic.js
+// Fail-safe xterm-compatible.
+
+// So far, we derivate from xterm-256color and then just add specific things (owned properties)
+// of xterm.generic.js, thus we achieve a clean inheritance model without duplicated code.
+
+
+// Fail-safe xterm-compatible.
+
+// So far, we derivate from xterm-256color and then just add specific things (owned properties)
+// of xterm.generic.js, thus we achieve a clean inheritance model without duplicated code.
+
+console.log( "exporting osx keymap" ) ;
+module.exports = {
+	esc: tree.extend( { own: true } , Object.create( xterm256.esc ) , xtermGeneric.esc ) ,
+	keymap: tree.extend( null , keymap , Object.create( xtermGeneric.keymap ) ) ,
+	// keymap: keymap ,
+	handler: Object.create( xtermGeneric.handler ) ,
+	support: {
+		deltaEscapeSequence: true ,
+		"256colors": true ,
+		"24bitsColors": undefined ,	// DEPRECATED
+		"trueColor": undefined	// maybe, maybe not
+	} ,
+	colorRegister: require( '../colorScheme/vga.json' )
+} ;
+
+

--- a/sample/key-config.js
+++ b/sample/key-config.js
@@ -1,0 +1,456 @@
+#!/usr/bin/env node
+/*
+	Terminal Kit
+
+	Copyright (c) 2009 - 2020 Cédric Ronvel
+
+	The MIT License (MIT)
+
+	Permission is hereby granted, free of charge, to any person obtaining a copy
+	of this software and associated documentation files (the "Software"), to deal
+	in the Software without restriction, including without limitation the rights
+	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+	copies of the Software, and to permit persons to whom the Software is
+	furnished to do so, subject to the following conditions:
+
+	The above copyright notice and this permission notice shall be included in all
+	copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+	SOFTWARE.
+*/
+
+// this is a little utility for getting the correct key mappings for new terminals
+
+"use strict" ;
+
+const terminal = require( '..' ) ;
+const inspect = require( 'util' ).inspect ;
+
+let done = false ;
+// turn events into an async function
+async function* eventGenerator( eventEmitter , ... events ) {
+	var queue = [] ;
+
+	// register event listener(s)
+	for ( let event of events ) {
+		eventEmitter.on( event , ( ... args ) => {
+			queue.push( args ) ;
+		} ) ;
+	}
+
+	// yeild events when they come in; delay 500ms between looking for events
+	while( ! done ) {
+		while( ! queue.length ) {
+			await delay( 50 ) ;
+		}
+		yield queue.shift() ;
+	}
+}
+
+let inputEvents = eventGenerator( process.stdin , "data" ) ;
+// get a key stroke
+async function getInput() {
+	let event = await inputEvents.next() ;
+	return event.value[0] ;
+}
+
+// wait `count` ms, similar to sleep()
+async function delay( count ) {
+	return new Promise( ( resolve ) => {
+		setTimeout( () => {
+			resolve() ;
+		} , count ) ;
+	} ) ;
+}
+
+var keyMap = new Map( [
+	[ "ESCAPE" , null ] ,
+	// [ "ENTER" , null ] ,
+	[ "BACKSPACE" , null ] ,
+	[ "NUL" , null ] ,
+	[ "TAB" , null ] ,
+	[ "SHIFT_TAB" , null ] ,
+	[ "UP" , null ] ,
+	[ "DOWN" , null ] ,
+	[ "RIGHT" , null ] ,
+	[ "LEFT" , null ] ,
+	[ "INSERT" , null ] ,
+	[ "DELETE" , null ] ,
+	[ "HOME" , null ] ,
+	[ "END" , null ] ,
+	[ "PAGE_UP" , null ] ,
+	[ "PAGE_DOWN" , null ] ,
+	[ "KP_NUMLOCK" , null ] ,
+	[ "KP_DIVIDE" , null ] ,
+	[ "KP_MULTIPLY" , null ] ,
+	[ "KP_MINUS" , null ] ,
+	[ "KP_PLUS" , null ] ,
+	[ "KP_DELETE" , null ] ,
+	[ "KP_ENTER" , null ] ,
+	[ "KP_0" , null ] ,
+	[ "KP_1" , null ] ,
+	[ "KP_2" , null ] ,
+	[ "KP_3" , null ] ,
+	[ "KP_4" , null ] ,
+	[ "KP_5" , null ] ,
+	[ "KP_6" , null ] ,
+	[ "KP_7" , null ] ,
+	[ "KP_8" , null ] ,
+	[ "KP_9" , null ] ,
+	[ "F1" , null ] ,
+	[ "F2" , null ] ,
+	[ "F3" , null ] ,
+	[ "F4" , null ] ,
+	[ "F5" , null ] ,
+	[ "F6" , null ] ,
+	[ "F7" , null ] ,
+	[ "F8" , null ] ,
+	[ "F9" , null ] ,
+	[ "F10" , null ] ,
+	[ "F11" , null ] ,
+	[ "F12" , null ] ,
+	[ "SHIFT_F1" , null ] ,
+	[ "SHIFT_F2" , null ] ,
+	[ "SHIFT_F3" , null ] ,
+	[ "SHIFT_F4" , null ] ,
+	[ "SHIFT_F5" , null ] ,
+	[ "SHIFT_F6" , null ] ,
+	[ "SHIFT_F7" , null ] ,
+	[ "SHIFT_F8" , null ] ,
+	[ "SHIFT_F9" , null ] ,
+	[ "SHIFT_F10" , null ] ,
+	[ "SHIFT_F11" , null ] ,
+	[ "SHIFT_F12" , null ] ,
+	[ "CTRL_F1" , null ] ,
+	[ "CTRL_F2" , null ] ,
+	[ "CTRL_F3" , null ] ,
+	[ "CTRL_F4" , null ] ,
+	[ "CTRL_F5" , null ] ,
+	[ "CTRL_F6" , null ] ,
+	[ "CTRL_F7" , null ] ,
+	[ "CTRL_F8" , null ] ,
+	[ "CTRL_F9" , null ] ,
+	[ "CTRL_F10" , null ] ,
+	[ "CTRL_F11" , null ] ,
+	[ "CTRL_F12" , null ] ,
+	[ "CTRL_SHIFT_F1" , null ] ,
+	[ "CTRL_SHIFT_F2" , null ] ,
+	[ "CTRL_SHIFT_F3" , null ] ,
+	[ "CTRL_SHIFT_F4" , null ] ,
+	[ "CTRL_SHIFT_F5" , null ] ,
+	[ "CTRL_SHIFT_F6" , null ] ,
+	[ "CTRL_SHIFT_F7" , null ] ,
+	[ "CTRL_SHIFT_F8" , null ] ,
+	[ "CTRL_SHIFT_F9" , null ] ,
+	[ "CTRL_SHIFT_F10" , null ] ,
+	[ "CTRL_SHIFT_F11" , null ] ,
+	[ "CTRL_SHIFT_F12" , null ] ,
+	[ "SHIFT_UP" , null ] ,
+	[ "SHIFT_DOWN" , null ] ,
+	[ "SHIFT_RIGHT" , null ] ,
+	[ "SHIFT_LEFT" , null ] ,
+	[ "ALT_UP" , null ] ,
+	[ "ALT_DOWN" , null ] ,
+	[ "ALT_RIGHT" , null ] ,
+	[ "ALT_LEFT" , null ] ,
+	[ "CTRL_UP" , null ] ,
+	[ "CTRL_DOWN" , null ] ,
+	[ "CTRL_RIGHT" , null ] ,
+	[ "CTRL_LEFT" , null ] ,
+	[ "SHIFT_INSERT" , null ] ,
+	[ "SHIFT_DELETE" , null ] ,
+	[ "SHIFT_HOME" , null ] ,
+	[ "SHIFT_END" , null ] ,
+	[ "SHIFT_PAGE_UP" , null ] ,
+	[ "SHIFT_PAGE_DOWN" , null ] ,
+	[ "CTRL_INSERT" , null ] ,
+	[ "CTRL_DELETE" , null ] ,
+	[ "CTRL_HOME" , null ] ,
+	[ "CTRL_END" , null ] ,
+	[ "CTRL_PAGE_UP" , null ] ,
+	[ "CTRL_PAGE_DOWN" , null ] ,
+	[ "ALT_BACKSPACE" , null ] ,
+	[ "ALT_INSERT" , null ] ,
+	[ "ALT_DELETE" , null ] ,
+	[ "ALT_HOME" , null ] ,
+	[ "ALT_END" , null ] ,
+	[ "ALT_PAGE_UP" , null ] ,
+	[ "ALT_PAGE_DOWN" , null ] ,
+	[ "SHIFT_TAB" , null ] ,
+	[ "ALT_TAB" , null ] ,
+	[ "ALT_SPACE" , null ] ,
+	[ "CTRL_ALT_SPACE" , null ] ,
+	[ "CTRL_A" , null ] ,
+	[ "ALT_A" , null ] ,
+	[ "CTRL_ALT_A" , null ] ,
+	[ "ALT_SHIFT_A" , null ] ,
+	[ "CTRL_B" , null ] ,
+	[ "ALT_B" , null ] ,
+	[ "CTRL_ALT_B" , null ] ,
+	[ "ALT_SHIFT_B" , null ] ,
+	[ "CTRL_C" , null ] ,
+	[ "ALT_C" , null ] ,
+	[ "CTRL_ALT_C" , null ] ,
+	[ "ALT_SHIFT_C" , null ] ,
+	[ "CTRL_D" , null ] ,
+	[ "ALT_D" , null ] ,
+	[ "CTRL_ALT_D" , null ] ,
+	[ "ALT_SHIFT_D" , null ] ,
+	[ "CTRL_E" , null ] ,
+	[ "ALT_E" , null ] ,
+	[ "CTRL_ALT_E" , null ] ,
+	[ "ALT_SHIFT_E" , null ] ,
+	[ "CTRL_F" , null ] ,
+	[ "ALT_F" , null ] ,
+	[ "CTRL_ALT_F" , null ] ,
+	[ "ALT_SHIFT_F" , null ] ,
+	[ "CTRL_G" , null ] ,
+	[ "ALT_G" , null ] ,
+	[ "CTRL_ALT_G" , null ] ,
+	[ "ALT_SHIFT_G" , null ] ,
+	[ "CTRL_H" , null ] ,
+	[ "ALT_H" , null ] ,
+	[ "CTRL_ALT_H" , null ] ,
+	[ "ALT_SHIFT_H" , null ] ,
+	[ "CTRL_I" , null ] ,
+	[ "ALT_I" , null ] ,
+	[ "CTRL_ALT_I" , null ] ,
+	[ "ALT_SHIFT_I" , null ] ,
+	[ "CTRL_J" , null ] ,
+	[ "ALT_J" , null ] ,
+	[ "CTRL_ALT_J" , null ] ,
+	[ "ALT_SHIFT_J" , null ] ,
+	[ "CTRL_K" , null ] ,
+	[ "ALT_K" , null ] ,
+	[ "CTRL_ALT_K" , null ] ,
+	[ "ALT_SHIFT_K" , null ] ,
+	[ "CTRL_L" , null ] ,
+	[ "ALT_L" , null ] ,
+	[ "CTRL_ALT_L" , null ] ,
+	[ "ALT_SHIFT_L" , null ] ,
+	[ "CTRL_M" , null ] ,
+	[ "ALT_M" , null ] ,
+	[ "CTRL_ALT_M" , null ] ,
+	[ "ALT_SHIFT_M" , null ] ,
+	[ "CTRL_N" , null ] ,
+	[ "ALT_N" , null ] ,
+	[ "CTRL_ALT_N" , null ] ,
+	[ "ALT_SHIFT_N" , null ] ,
+	[ "CTRL_O" , null ] ,
+	[ "ALT_O" , null ] ,
+	[ "CTRL_ALT_O" , null ] ,
+	[ "ALT_SHIFT_O" , null ] ,
+	[ "CTRL_P" , null ] ,
+	[ "ALT_P" , null ] ,
+	[ "CTRL_ALT_P" , null ] ,
+	[ "ALT_SHIFT_P" , null ] ,
+	[ "CTRL_Q" , null ] ,
+	[ "ALT_Q" , null ] ,
+	[ "CTRL_ALT_Q" , null ] ,
+	[ "ALT_SHIFT_Q" , null ] ,
+	[ "CTRL_R" , null ] ,
+	[ "ALT_R" , null ] ,
+	[ "CTRL_ALT_R" , null ] ,
+	[ "ALT_SHIFT_R" , null ] ,
+	[ "CTRL_S" , null ] ,
+	[ "ALT_S" , null ] ,
+	[ "CTRL_ALT_S" , null ] ,
+	[ "ALT_SHIFT_S" , null ] ,
+	[ "CTRL_T" , null ] ,
+	[ "ALT_T" , null ] ,
+	[ "CTRL_ALT_T" , null ] ,
+	[ "ALT_SHIFT_T" , null ] ,
+	[ "CTRL_U" , null ] ,
+	[ "ALT_U" , null ] ,
+	[ "CTRL_ALT_U" , null ] ,
+	[ "ALT_SHIFT_U" , null ] ,
+	[ "CTRL_V" , null ] ,
+	[ "ALT_V" , null ] ,
+	[ "CTRL_ALT_V" , null ] ,
+	[ "ALT_SHIFT_V" , null ] ,
+	[ "CTRL_W" , null ] ,
+	[ "ALT_W" , null ] ,
+	[ "CTRL_ALT_W" , null ] ,
+	[ "ALT_SHIFT_W" , null ] ,
+	[ "CTRL_X" , null ] ,
+	[ "ALT_X" , null ] ,
+	[ "CTRL_ALT_X" , null ] ,
+	[ "ALT_SHIFT_X" , null ] ,
+	[ "CTRL_Y" , null ] ,
+	[ "ALT_Y" , null ] ,
+	[ "CTRL_ALT_Y" , null ] ,
+	[ "ALT_SHIFT_Y" , null ] ,
+	[ "CTRL_Z" , null ] ,
+	[ "ALT_Z" , null ] ,
+	[ "CTRL_ALT_Z" , null ] ,
+	[ "ALT_SHIFT_Z" , null ]
+
+	// [ "a" , null ] ,
+	// [ "b" , null ] ,
+	// [ "c" , null ] ,
+	// [ "d" , null ] ,
+	// [ "e" , null ] ,
+	// [ "f" , null ] ,
+	// [ "g" , null ] ,
+	// [ "h" , null ] ,
+	// [ "i" , null ] ,
+	// [ "j" , null ] ,
+	// [ "k" , null ] ,
+	// [ "l" , null ] ,
+	// [ "m" , null ] ,
+	// [ "n" , null ] ,
+	// [ "o" , null ] ,
+	// [ "p" , null ] ,
+	// [ "q" , null ] ,
+	// [ "r" , null ] ,
+	// [ "s" , null ] ,
+	// [ "t" , null ] ,
+	// [ "u" , null ] ,
+	// [ "v" , null ] ,
+	// [ "w" , null ] ,
+	// [ "x" , null ] ,
+	// [ "y" , null ] ,
+	// [ "z" , null ] ,
+	// [ "A" , null ] ,
+	// [ "B" , null ] ,
+	// [ "C" , null ] ,
+	// [ "D" , null ] ,
+	// [ "E" , null ] ,
+	// [ "F" , null ] ,
+	// [ "G" , null ] ,
+	// [ "H" , null ] ,
+	// [ "I" , null ] ,
+	// [ "J" , null ] ,
+	// [ "K" , null ] ,
+	// [ "L" , null ] ,
+	// [ "M" , null ] ,
+	// [ "N" , null ] ,
+	// [ "O" , null ] ,
+	// [ "P" , null ] ,
+	// [ "Q" , null ] ,
+	// [ "R" , null ] ,
+	// [ "S" , null ] ,
+	// [ "T" , null ] ,
+	// [ "U" , null ] ,
+	// [ "V" , null ] ,
+	// [ "W" , null ] ,
+	// [ "X" , null ] ,
+	// [ "Y" , null ] ,
+	// [ "Z" , null ] ,
+	// [ "1" , null ] ,
+	// [ "2" , null ] ,
+	// [ "3" , null ] ,
+	// [ "4" , null ] ,
+	// [ "5" , null ] ,
+	// [ "6" , null ] ,
+	// [ "7" , null ] ,
+	// [ "8" , null ] ,
+	// [ "9" , null ] ,
+	// [ "0" , null ] ,
+	// [ "`" , null ] ,
+	// [ "~" , null ] ,
+	// [ "!" , null ] ,
+	// [ "@" , null ] ,
+	// [ "#" , null ] ,
+	// [ "$" , null ] ,
+	// [ "%" , null ] ,
+	// [ "^" , null ] ,
+	// [ "&" , null ] ,
+	// [ "*" , null ] ,
+	// [ "(" , null ] ,
+	// [ ")" , null ] ,
+	// [ "_" , null ] ,
+	// [ "-" , null ] ,
+	// [ "+" , null ] ,
+	// [ "=" , null ] ,
+	// [ "[" , null ] ,
+	// [ "]" , null ] ,
+	// [ "{" , null ] ,
+	// [ "}" , null ] ,
+	// [ "|" , null ] ,
+	// [ "\\" , null ] ,
+	// [ ":" , null ] ,
+	// [ ";" , null ] ,
+	// [ "\"" , null ] ,
+	// [ "'" , null ] ,
+	// [ "," , null ] ,
+	// [ "<" , null ] ,
+	// [ "." , null ] ,
+	// [ ">" , null ] ,
+	// [ "/" , null ] ,
+	// [ "?" , null ]
+] ) ;
+
+// convert type Buffer to a escaped string
+function bufToEscStr( buf ) {
+	let retStr = "" ;
+	for ( let b of buf ) {
+		if ( b < 0x20 || b > 0x7E ) {
+			retStr += `\\x${b.toString( 16 )}` ;
+		}
+		else {
+			retStr += String.fromCharCode( b ) ;
+		}
+	}
+	return retStr ;
+}
+
+var term ;
+// check if the user entered key matches the detected terminal key
+function sameKey( key ) {
+	let termKey = term.keymap[key][0].code ;
+	termKey = bufToEscStr( Buffer.from( termKey.split( "" ).map( ( ch ) => ch.charCodeAt( 0 ) ) ) ) ;
+	let newKey = keyMap.get( key ) ;
+	// console.log ( `termKey: '${termKey}' ... newKey: '${newKey}' ... same: ${termKey === newKey}` ) ;
+	return termKey === newKey ;
+}
+
+/* main IIFE */
+( async function() {
+	term = await terminal.getDetectedTerminal() ;
+	process.stdin.setRawMode( true ) ;
+	process.stdin.resume() ;
+	let enter ;
+
+	// get the ENTER key
+	process.stdout.write( `Please press the ENTER key: ` ) ;
+	enter = await getInput() ;
+	console.log( enter ) ;
+	keyMap.set( "ENTER" , bufToEscStr ( enter ) ) ;
+
+	// prompt the user for each key
+	for ( let key of [ ... keyMap.keys() ] ) {
+		if ( key === "ENTER" ) continue ;
+		process.stdout.write( `Please press the '${key}' key (or press ENTER to skip): ` ) ;
+		let val = await getInput() ;
+		if ( ! Buffer.compare( val , enter ) ) {
+			keyMap.delete( key ) ;
+			console.log( "<< skipped >>" ) ;
+			continue ;
+		}
+		console.log( val ) ;
+		keyMap.set( key , bufToEscStr ( val ) ) ;
+		if( sameKey( key ) ) keyMap.delete( key ) ;
+	}
+
+	// we were using ENTER to skip before, but now we need to delete if if we don't need it
+	if( sameKey( "ENTER" ) ) keyMap.delete( "ENTER" ) ;
+
+	// print JavaScript keymap object for termconfig file
+	console.log( "" ) ;
+	console.log( "const keymap = {" ) ;
+	for ( let key of [ ... keyMap.keys() ] ) {
+		console.log( `	${key}: '${keyMap.get( key )}' ,` ) ;
+	}
+	console.log( "} ) ;" ) ;
+
+	process.exit( 0 ) ;
+}() ) ;
+
+


### PR DESCRIPTION
Implements `getDetectedTerminal` for OSX terminals and adds a `osx-256color.js` termconfig.

Please review the changes in `getDetectedTerminal` -- I added a `basename()` call to get the application name of the OSX terminals in a path independent manner. I'm assuming that works for other terminals, but have no way to check. I also modified the finding of the `parentPid` since OSX had slightly different output formatting from the `exec(ps)` command.

I also added a `key-config` utility under samples that allows users to enter their keys and spit out a new `keymap` object.

Note that this  implementation isn't functional due to the problems described in #126 