### PR TITLE
wrong parameter to `scroll` function in Container onKey event handler

### DIFF
--- a/lib/document/Container.js
+++ b/lib/document/Container.js
@@ -317,27 +317,27 @@ Container.prototype.drawSelfCursor = function( elementTargeted ) {
 Container.prototype.onKey = function( key , trash , data ) {
 	switch( this.keyBindings[ key ] ) {
 		case 'tinyScrollUp' :
-			this.scroll( 0 , Math.ceil( this.textAreaHeight / 5 ) ) ;
+			this.scroll( 0 , Math.ceil( this.viewportHeight / 5 ) ) ;
 			break ;
 
 		case 'tinyScrollDown' :
-			this.scroll( 0 , -Math.ceil( this.textAreaHeight / 5 ) ) ;
+			this.scroll( 0 , -Math.ceil( this.viewportHeight / 5 ) ) ;
 			break ;
 
 		case 'scrollUp' :
-			this.scroll( 0 , Math.ceil( this.textAreaHeight / 2 ) ) ;
+			this.scroll( 0 , Math.ceil( this.viewportHeight / 2 ) ) ;
 			break ;
 
 		case 'scrollDown' :
-			this.scroll( 0 , -Math.ceil( this.textAreaHeight / 2 ) ) ;
+			this.scroll( 0 , -Math.ceil( this.viewportHeight / 2 ) ) ;
 			break ;
 
 		case 'scrollLeft' :
-			this.scroll( Math.ceil( this.textAreaWidth / 2 ) , 0 ) ;
+			this.scroll( Math.ceil( this.viewportWidth / 2 ) , 0 ) ;
 			break ;
 
 		case 'scrollRight' :
-			this.scroll( -Math.ceil( this.textAreaWidth / 2 ) , 0 ) ;
+			this.scroll( -Math.ceil( this.viewportWidth / 2 ) , 0 ) ;
 			break ;
 
 		case 'scrollTop' :


### PR DESCRIPTION
- Use viewportWidth(Height) instead of textAreaWidth(Height)
- Refer to the implementation of `onWheel` event handler

see https://github.com/cronvel/terminal-kit/issues/130