### PR TITLE
Fix bug in rate calculation in progress bar

### DIFF
--- a/lib/document/Bar.js
+++ b/lib/document/Bar.js
@@ -79,7 +79,7 @@ Bar.prototype.preDrawSelf = function() {
 		noPartialCell = false ,
 		partialCell = null ,
 		innerSize = this.outputWidth - 2 ,
-		rate = this.value - this.minValue / ( this.maxValue - this.minValue ) ;
+		rate = (this.value - this.minValue) / ( this.maxValue - this.minValue ) ;
 
 	if ( ! rate || rate < 0 ) { rate = 0 ; }
 	else if ( rate > 1 ) { rate = 1 ; }


### PR DESCRIPTION
This fixes the rendering of progress bars with non-default `minValue` and `maxValue` options. These options are essentially useless without this patch.