### PR TITLE
Fix BACKSPACE issue

### DIFF
--- a/lib/termconfig/osx-256color.js
+++ b/lib/termconfig/osx-256color.js
@@ -38,7 +38,7 @@ const keymap = tree.extend( null , Object.create( xterm256Generic.keymap ) , {
 	DOWN: '\x1b[B' ,
 	RIGHT: '\x1b[C' ,
 	LEFT: '\x1b[D' ,
-	DELETE: '\x7f' ,
+	BACKSPACE: '\x7f' ,
 	SHIFT_F1: '\x1b[1;2P' ,
 	SHIFT_F2: '\x1b[1;2Q' ,
 	SHIFT_F3: '\x1b[1;2R' ,


### PR DESCRIPTION
Corrected a defect with backspace triggering a delete instead. Issue #154

Tested in two terminals. Output for ./sample/key-test.js below

terminal
```
Key: BACKSPACE , length: 9 , all matches: [ 'BACKSPACE' ] , is character: false , codepoint:  , buffer: <Buffer 7f>
Key: DELETE , length: 6 , all matches: [ 'DELETE' ] , is character: false , codepoint:  , buffer: <Buffer 1b 5b 33 7e>
```

iterm2
```
Key: BACKSPACE , length: 9 , all matches: [ 'BACKSPACE' ] , is character: false , codepoint:  , buffer: <Buffer 7f>
Key: DELETE , length: 6 , all matches: [ 'DELETE' ] , is character: false , codepoint:  , buffer: <Buffer 1b 5b 33 7e>
```