### PR TITLE
Added capability to select a row in TextTable

### DIFF
--- a/lib/document/TextTable.js
+++ b/lib/document/TextTable.js
@@ -33,7 +33,6 @@ const TextBox = require( './TextBox.js' ) ;
 const boxesChars = require( '../spChars.js' ).box ;
 
 
-
 function TextTable( options ) {
 	// Clone options if necessary
 	options = ! options ? {} : options.internal ? options : Object.create( options ) ;
@@ -91,6 +90,7 @@ function TextTable( options ) {
 
 	this.hasBorder = options.hasBorder !== undefined ? !! options.hasBorder : true ;	// Default to true
 	this.borderAttr = options.borderAttr || this.textAttr ;
+	this.selectedRowTextAttr = options.selectedRowTextAttr;
 	this.borderChars = boxesChars.light ;
 
 	if ( typeof options.borderChars === 'object' ) {
@@ -128,7 +128,38 @@ TextTable.prototype.staticInline = true ;
 
 TextTable.prototype.textBoxKeyBindings = TextBox.prototype.keyBindings ;
 
+/** Select the given row and redraw the table */
+TextTable.prototype.selectRow = function(idx) {
+    this.selectedRow = idx;
 
+    // Treat out of range value as null
+    if (this.selectedRow < 0 || this.selectedRow > this.rowCount) { this.selectedRow = null; }
+
+    
+    // Refresh
+    this.initChildren(); // Re-generate rows so we can update highlighting
+    this.computeCells();
+    this.draw();
+
+}
+
+/** Select the next row in the table, or the current row plus specified index. */
+TextTable.prototype.selectNextRow = function(idx=1) {
+    if (this.selectedRow == null) {
+        this.selectRow(idx);
+    } else {
+        this.selectRow(this.selectedRow+idx);
+    }
+}
+
+/** Select the previous row (or row minus index) in the table. If no row is currently selected, the nth row from the end of the table will be selected. */
+TextTable.prototype.selectPrevRow = function(idx=1) {
+    if (this.selectedRow == null) {
+        this.selectRow(this.rowCount-idx);
+    } else {
+        this.selectRow(this.selectedRow-idx);
+    }
+}
 
 TextTable.prototype.setCellContent = function( x , y , content , dontDraw = false , dontUpdateLayout = false ) {
 	var textBox = this.textBoxes[ y ] && this.textBoxes[ y ][ x ] ;
@@ -163,6 +194,7 @@ TextTable.prototype.initChildren = function() {
 			if ( x >= this.columnCount ) { this.columnCount = x + 1 ; }
 
 			textAttr =
+				this.selectedRowTextAttr && this.selectedRow != null && y == this.selectedRow  ?  this.selectedRowTextAttr  :
 				this.firstCellTextAttr && ! x && ! y  ?  this.firstCellTextAttr  :
 				this.firstRowTextAttr && ! y  ?  this.firstRowTextAttr  :
 				this.firstColumnTextAttr && ! x  ?  this.firstColumnTextAttr  :

--- a/sample/document/text-table-test.js
+++ b/sample/document/text-table-test.js
@@ -77,6 +77,10 @@ var textTable = new termkit.TextTable( {
 	fit: true ,	// Activate all expand/shrink + wordWrap
 	//expandToWidth: true , shrinkToWidth: true , expandToHeight: true , shrinkToHeight: true , wordWrap: true ,
 	//lineWrap: true ,
+
+    // Custom:
+    borderSelAttr: { color: 'green' },
+    selectedRowTextAttr: { bgColor: 'green', color: 'black' },
 } ) ;
 
 setTimeout( () => {
@@ -84,8 +88,10 @@ setTimeout( () => {
 } , 1200 ) ;
 
 
+var activeRow = 1;
 term.on( 'key' , function( key ) {
 	switch( key ) {
+		case 'q':
 		case 'CTRL_C' :
 			term.grabInput( false ) ;
 			term.hideCursor( false ) ;
@@ -93,6 +99,12 @@ term.on( 'key' , function( key ) {
 			term.clear() ;
 			process.exit() ;
 			break ;
+		case 'UP' :
+			textTable.selectPrevRow();
+			break;
+		case 'DOWN':
+			textTable.selectNextRow();
+			break;
 	}
 } ) ;
 


### PR DESCRIPTION
The ability to select rows in tables enables a lot of functionality for more complicated UIs.  This could potentially be extended with equivalent functions for selecting columns, cells, or even ranges, but I've only implemented the basic row selection ability that meets my current needs.  

Defined selectedRowTextAttr to define how to display the selected row, and the methods selectRow(idx), selectNextRow() and selectPrevRow().  I've also updated the text-table-test.js sample to reflect this new functionality.