### PR TITLE
Reduce package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,11 @@
       2021
     ],
     "owner": "Cédric Ronvel"
-  }
+  },
+  "files": [
+    "browser/",
+    "lib/",
+    "LICENSE",
+    "README.md"
+  ],
 }


### PR DESCRIPTION
npm package contains files like doc, test etc which are unnecessary for applications. Unpacked size of the package is 4.65MB. This is huge. You can limit files to be packed by npm.