### PR TITLE
fix: propagate autoWidth and autoHeight options  to EditableTextBox…

### DIFF
--- a/lib/document/LabeledInput.js
+++ b/lib/document/LabeledInput.js
@@ -209,8 +209,6 @@ LabeledInput.prototype.initInput = function( options ) {
 	this.input.on( 'focus' , this.onChildFocus.bind( this ) ) ;
 } ;
 
-
-
 LabeledInput.prototype.initTextInput = function( options ) {
 	if ( options.inputKeyBindings ) { this.inputKeyBindings = options.inputKeyBindings ; }
 	else if ( options.allowNewLine ) { this.inputKeyBindings = this.multiLineEditableTextBoxKeyBindings ; }
@@ -234,7 +232,9 @@ LabeledInput.prototype.initTextInput = function( options ) {
 		textAttr: this.textAttr ,
 		voidAttr: this.voidAttr ,
 		keyBindings: this.inputKeyBindings ,
-		noDraw: true
+		noDraw: true,
+		autoWidth: options.autoWidth,
+		autoHeight: options.autoHeight
 	} ) ;
 } ;
 


### PR DESCRIPTION
In `LabeledInput` element  on `initTextInput` the properties `autoWidth` and `autoHeight` are not propagated to the created `EditableTextBox` affecting behaviour of `onParentResize`