### PR TITLE
Fix: Add \r for drawing images

### DIFF
--- a/lib/Terminal.js
+++ b/lib/Terminal.js
@@ -2211,7 +2211,7 @@ notChainable.drawNdarrayImage = function( pixels /* , options */ ) {
 			}
 		}
 
-		this.styleReset()( '\n' ) ;
+		this.styleReset()( '\n\r' ) ;
 	}
 } ;
 


### PR DESCRIPTION
Currently, this doesn't work over an ssh session, adding \r properly adds line breaks.