### PR TITLE
Add complete documentation for Layout and Text widgets

### DIFF
--- a/doc/Layout.md
+++ b/doc/Layout.md
@@ -1,6 +1,96 @@
-
 <a name="top"></a>
 <a name="ref.Layout"></a>
 ## Layout
 
-TODOC
+A *Layout* is a responsive container widget that divides the available space into rows and columns, creating nested containers.
+It's useful for creating complex user interfaces with multiple panels. The layout is fully responsive and will adjust when the terminal is resized.
+
+Each box in the layout is an independent container that can hold other widgets. Boxes can be created with fixed sizes, percentage-based sizes, or automatic sizing.
+
+<a name="ref.Layout.toc"></a>
+## Table of Contents
+
+* [Events](#ref.Layout.event)
+	* [parentResize](#ref.Layout.event.parentResize)
+
+* Constructor:
+	* [new Layout()](#ref.Layout.new)
+
+* Methods:
+	* [.computeBoundingBoxes()](#ref.Layout.computeBoundingBoxes)
+	* [.onParentResize()](#ref.Layout.onParentResize)
+
+* Inherit methods and properties from [Element](Element.md#ref.Element.toc)
+
+<a name="ref.Layout.event"></a>
+### Events
+
+<a name="ref.Layout.event.parentResize"></a>
+#### *parentResize*
+
+This event is triggered when the parent container is resized, allowing the layout to recalculate its boxes.
+
+<a name="ref.Layout.new"></a>
+### new Layout( options )
+
+* options `Object`, where:
+	* *all [the base class Element constructor's](Element.md#ref.Element.new) options*
+	* layout `Object` defining the layout structure with the following properties:
+		* id `string` the identifier for this layout box
+		* x, y `number` (optional) the offset from the parent container
+		* width, height `number` (optional) fixed size in cells
+		* widthPercent, heightPercent `number` (optional) size as a percentage of the parent container
+		* rows `Array` (optional) an array of row definitions
+		* columns `Array` (optional) an array of column definitions
+	* boxChars `string` or `Object` the box drawing characters to use, can be 'light' (default) or 'double', or a custom object
+
+This creates a *Layout element* with nested containers.
+
+<a name="ref.Layout.computeBoundingBoxes"></a>
+### .computeBoundingBoxes()
+
+Recalculates the size and position of all layout boxes based on the current terminal size and layout definition.
+This is called automatically when the layout is created and when the terminal is resized.
+
+<a name="ref.Layout.onParentResize"></a>
+### .onParentResize()
+
+Handler for the parentResize event. Recalculates bounding boxes when the parent container is resized.
+
+## Example
+
+```javascript
+var layout = new termkit.Layout({
+    parent: document,
+    boxChars: 'double',
+    layout: {
+        id: 'main',
+        widthPercent: 100,
+        heightPercent: 80,
+        rows: [
+            {
+                id: 'top-row',
+                heightPercent: 75,
+                columns: [
+                    { id: 'left-panel', widthPercent: 33 },
+                    { id: 'middle-panel' }, // auto width
+                    { id: 'right-panel', width: 30 } // fixed width
+                ]
+            },
+            {
+                id: 'bottom-row',
+                columns: [
+                    { id: 'bottom-left', width: 20 },
+                    { id: 'bottom-right' } // auto width
+                ]
+            }
+        ]
+    }
+});
+
+// Add widgets to containers
+new termkit.Text({
+    parent: document.elements['left-panel'],
+    content: 'Left panel content'
+});
+```

--- a/doc/Text.md
+++ b/doc/Text.md
@@ -1,6 +1,102 @@
-
 <a name="top"></a>
 <a name="ref.Text"></a>
 ## Text
 
-TODOC
+A *Text* is a basic widget that displays text content with optional formatting.
+It can display plain text or content with markup/ANSI formatting, and supports features like padding and content ellipsis.
+Text widgets can have fixed sizes or adapt their size automatically to the content.
+
+<a name="ref.Text.toc"></a>
+## Table of Contents
+
+* Events: Inherits from [Element](Element.md#ref.Element.event)
+
+* Constructor:
+	* [new Text()](#ref.Text.new)
+
+* Methods:
+	* [.setContent()](#ref.Text.setContent)
+	* [.computeRequiredWidth()](#ref.Text.computeRequiredWidth)
+	* [.computeRequiredHeight()](#ref.Text.computeRequiredHeight)
+	* [.resizeOnContent()](#ref.Text.resizeOnContent)
+
+* Inherit methods and properties from [Element](Element.md#ref.Element.toc)
+
+<a name="ref.Text.new"></a>
+### new Text( options )
+
+* options `Object`, where:
+	* *all [the base class Element constructor's](Element.md#ref.Element.new) options*
+	* attr `object` attributes for the text, default to `{ bgColor: 'brightBlack' }`
+	* content `string` or `Array` of strings, the text content of the widget
+	* contentHasMarkup `boolean` or `string` when set to *true*, the content contains Terminal Kit's markup,
+	  when set to *'ansi'* or *'legacyAnsi'*, the content contains ANSI escape sequences, default: false
+	* leftPadding `string` text to display before the content, default: ''
+	* rightPadding `string` text to display after the content, default: ''
+	* paddingHasMarkup `boolean` when true, padding strings can contain markup, default: false
+	* contentEllipsis `string` or `boolean` character(s) to display when content is clipped, if true it's '…', default: ''
+	* contentAdaptativeWidth `boolean` when true, the widget width adapts to the content width, default: true if width is not provided
+	* contentAdaptativeHeight `boolean` when true, the widget height adapts to the content height, default: true if height is not provided
+
+This creates a *Text element* to display formatted text.
+
+<a name="ref.Text.setContent"></a>
+### .setContent( content , hasMarkup , [dontDraw] , [dontResize] )
+
+* content `string` or `Array` of strings, the new text content
+* hasMarkup `boolean` or `string` whether the content has markup, 'ansi', or 'legacyAnsi' formatting
+* dontDraw `boolean` if true, don't redraw the element (default: false)
+* dontResize `boolean` if true, don't resize the element even if adaptative size is enabled (default: false)
+
+Updates the text content of the widget. If the content is a multiline array and `forceContentArray` is true (default),
+the content will be treated as multiple lines.
+
+<a name="ref.Text.computeRequiredWidth"></a>
+### .computeRequiredWidth()
+
+Calculates the width required for the content including left and right padding. Returns the inner width.
+
+<a name="ref.Text.computeRequiredHeight"></a>
+### .computeRequiredHeight()
+
+Calculates the height required for the content. Returns the content height.
+
+<a name="ref.Text.resizeOnContent"></a>
+### .resizeOnContent()
+
+Adjusts the widget dimensions based on content if contentAdaptativeWidth or contentAdaptativeHeight are enabled.
+
+## Example
+
+```javascript
+// Simple text display
+var text = new termkit.Text({
+    parent: document,
+    content: 'Simple text content',
+    attr: { color: 'blue', bgColor: 'black' },
+    x: 10,
+    y: 5
+});
+
+// Text with markup
+var markupText = new termkit.Text({
+    parent: document,
+    content: '^[fg:*royal-blue]Text with ^[fg:red]color^:',
+    contentHasMarkup: true,
+    x: 10,
+    y: 7
+});
+
+// Multiline text with padding
+var paddedText = new termkit.Text({
+    parent: document,
+    content: ['First line', 'Second line'],
+    leftPadding: '| ',
+    rightPadding: ' |',
+    contentEllipsis: '…',
+    attr: { bgColor: 'magenta' },
+    x: 10,
+    y: 10,
+    width: 20
+});
+```


### PR DESCRIPTION
## Summary
- Added comprehensive documentation for the Layout widget, including API reference and examples
- Added comprehensive documentation for the Text widget, including API reference and examples
- Both widgets were previously marked with "TODOC" placeholders

## Test plan
- Documentation can be verified by comparing the API to the implementation code
- Examples demonstrate proper usage of the widgets

🤖 Generated with [Claude Code](https://claude.ai/code)